### PR TITLE
Phase 1 – Infrastructure First: Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Git and local metadata
+.git
+.gitignore
+
+# Python cache and virtual envs
+__pycache__/
+**/__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.venv/
+venv/
+
+# IDE/editor files
+.vscode/
+.idea/
+
+# Local runtime/state folders mounted in compose
+logs/
+data/
+
+# Secrets and local env files
+.env
+.env.*
+
+# Test and build artifacts
+.pytest_cache/
+.coverage
+htmlcov/
+*.log
+
+# Documentation and planning not needed in runtime image
+README.md
+ROADMAP.md
+plan/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,64 @@
+# ==============================
+# Required credentials
+# ==============================
+KRAKEN_API_KEY=your_kraken_api_key
+KRAKEN_API_SECRET=your_kraken_api_secret
+TELEGRAM_TOKEN=your_telegram_bot_token
+TELEGRAM_USER_ID=123456789
+
+# ==============================
+# Core bot settings
+# ==============================
+PAIRS=XBTEUR,ETHEUR
+SLEEPING_INTERVAL=60
+PARAM_SESSIONS=720
+CANDLE_TIMEFRAME=15
+MARKET_DATA_DAYS=60
+ATR_PERIOD=14
+ATR_DESV_LIMIT=0.2
+MIN_VALUE=10
+TELEGRAM_POLL_INTERVAL=0
+MINIMUM_CHANGE_PCT=0.02
+
+# ==============================
+# Future data services (optional)
+# Enable when running docker compose with profile: data
+# ==============================
+POSTGRES_DB=botc
+POSTGRES_USER=botc
+POSTGRES_PASSWORD=change_me_with_a_strong_password
+POSTGRES_HOST=postgres
+POSTGRES_PORT=5432
+
+REDIS_HOST=redis
+REDIS_PORT=6379
+REDIS_DB=0
+# REDIS_PASSWORD=
+
+# Optional convenience URLs for future app migration
+DATABASE_URL=postgresql://botc:change_me_with_a_strong_password@postgres:5432/botc
+REDIS_URL=redis://redis:6379/0
+
+# ==============================
+# Pair allocation and behavior
+# Use one block per pair listed in PAIRS
+# ==============================
+XBTEUR_TARGET_PCT=50
+XBTEUR_HODL_PCT=25
+XBTEUR_K_ACT=1.20
+XBTEUR_MIN_MARGIN=0
+XBTEUR_STOP_PCT_LL=0.90
+XBTEUR_STOP_PCT_LV=0.90
+XBTEUR_STOP_PCT_MV=0.90
+XBTEUR_STOP_PCT_HV=0.90
+XBTEUR_STOP_PCT_HH=0.90
+
+ETHEUR_TARGET_PCT=50
+ETHEUR_HODL_PCT=25
+ETHEUR_K_ACT=1.20
+ETHEUR_MIN_MARGIN=0
+ETHEUR_STOP_PCT_LL=0.90
+ETHEUR_STOP_PCT_LV=0.90
+ETHEUR_STOP_PCT_MV=0.90
+ETHEUR_STOP_PCT_HV=0.90
+ETHEUR_STOP_PCT_HH=0.90

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 
 COPY requirements.txt /tmp/requirements.txt
 
-# requirements.txt in this repository is UTF-16; convert to UTF-8 for pip.
-RUN python -c "from pathlib import Path; p=Path('/tmp/requirements.txt'); p.write_text(p.read_text(encoding='utf-16'), encoding='utf-8')" \
-    && pip install --upgrade pip \
+RUN pip install --upgrade pip \
     && pip install --no-cache-dir -r /tmp/requirements.txt
 
 FROM python:3.12-slim AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+FROM python:3.12-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Build virtualenv with dependencies in an isolated location.
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+COPY requirements.txt /tmp/requirements.txt
+
+# requirements.txt in this repository is UTF-16; convert to UTF-8 for pip.
+RUN python -c "from pathlib import Path; p=Path('/tmp/requirements.txt'); p.write_text(p.read_text(encoding='utf-16'), encoding='utf-8')" \
+    && pip install --upgrade pip \
+    && pip install --no-cache-dir -r /tmp/requirements.txt
+
+FROM python:3.12-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/opt/venv/bin:$PATH"
+
+WORKDIR /app
+
+RUN groupadd --system appgroup \
+    && useradd --system --gid appgroup --create-home appuser
+
+COPY --from=builder /opt/venv /opt/venv
+COPY . /app
+
+RUN mkdir -p /app/data /app/logs \
+    && chown -R appuser:appgroup /app
+
+USER appuser
+
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -492,6 +492,8 @@ docker compose down
 
 Optional (future data migration with PostgreSQL + Redis):
 
+> **Note:** This also starts the default `botc` service. To start only `postgres`/`redis`, add them explicitly: `docker compose --profile data up -d postgres redis`.
+
 ```bash
 docker compose --profile data up -d
 ```

--- a/README.md
+++ b/README.md
@@ -466,6 +466,15 @@ All logs include timestamps and are organized by:
 
 ### Docker
 
+Two Compose files are provided:
+
+| File | Purpose |
+|---|---|
+| `docker-compose.yml` | **Development** – bind-mounts `./data` and `./logs` so you can inspect files directly on the host. |
+| `docker-compose.prod.yml` | **Production (VPS)** – layered override that switches to named volumes (fixes Linux ownership for the non-root container user), enforces `restart: always`, and adds runtime hardening. |
+
+#### Development
+
 1. Copy the environment template:
 
 ```bash
@@ -497,6 +506,23 @@ Optional (future data migration with PostgreSQL + Redis):
 ```bash
 docker compose --profile data up -d
 ```
+
+#### Production (Linux VPS)
+
+Layer the production override on top of the base file:
+
+```bash
+# First deploy
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+
+# Watch logs
+docker compose -f docker-compose.yml -f docker-compose.prod.yml logs -f botc
+
+# Stop
+docker compose -f docker-compose.yml -f docker-compose.prod.yml down
+```
+
+> **Note:** On production, `./data` and `./logs` are stored in Docker named volumes (`botc_data` and `botc_logs`). To find the exact runtime volume names run `docker volume ls | grep botc`, then inspect with `docker volume inspect <volume-name>` or copy files out with `docker cp`.
 
 ### Analysis Tools
 

--- a/README.md
+++ b/README.md
@@ -464,44 +464,61 @@ All logs include timestamps and are organized by:
 
 ## 🚀 Quick Start
 
-### Prerequisites
+### Docker
+
+1. Copy the environment template:
 
 ```bash
-pip install -r requirements.txt
+cp .env.example .env
 ```
 
-**Dependencies**:
-- `pandas` & `numpy`: Data analysis and vectorized calculations
-- `scipy`: Statistical signal processing for pivot detection
-- `krakenex`: Kraken exchange integration
-- `python-telegram-bot`: Telegram bot interface
-- `python-dotenv`: Environment configuration management
+2. Build and start the bot:
 
-### Local Execution
-
-1. **Configure Environment**:
-   
-   Create a `.env` file in the project root with the configuration variables shown in the [Environment Variables](#environment-variables) section above.
-
-2. **Run Bot**:
 ```bash
-python main.py
+docker compose up -d --build
+```
+
+3. Watch logs:
+
+```bash
+docker compose logs -f botc
+```
+
+4. Stop services:
+
+```bash
+docker compose down
+```
+
+Optional (future data migration with PostgreSQL + Redis):
+
+```bash
+docker compose --profile data up -d
 ```
 
 ### Analysis Tools
 
+Run analysis scripts using Docker:
+
 **Market Structure Analysis**:
 ```bash
-python trading/market_analyzer.py PAIR=XBTEUR Volatility=ALL SHOW_EVENTS
+docker compose run --rm botc python trading/market_analyzer.py PAIR=XBTEUR Volatility=ALL SHOW_EVENTS
 ```
 
 **Backtest Strategy**:
 ```bash
-python trading/backtest.py PAIR=XBTEUR FEE_PCT=0.26
+docker compose run --rm botc python trading/backtest.py PAIR=XBTEUR FEE_PCT=0.26 START=2025-01-01 END=2026-01-01
 ```
 
 **Parameter Optimization**:
 ```bash
+docker compose run --rm botc python trading/optimize_params.py PAIR=XBTEUR MODE=CONSERVATIVE FEE_PCT=0.26
+```
+
+Or run locally with Python:
+```bash
+python trading/market_analyzer.py PAIR=XBTEUR Volatility=ALL SHOW_EVENTS
+python trading/backtest.py PAIR=XBTEUR FEE_PCT=0.26
 python trading/optimize_params.py PAIR=XBTEUR MODE=CONSERVATIVE FEE_PCT=0.26
 ```
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,29 @@
+# docker-compose.prod.yml — production overrides for Linux VPS deployment.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+#
+# This file is layered on top of docker-compose.yml. It:
+#   - Replaces host bind-mounts with named volumes so that the container's
+#     non-root user (appuser) has correct ownership regardless of host UIDs.
+#   - Restarts the service unconditionally (suitable for a long-lived VPS process).
+#   - Adds no-new-privileges to prevent privilege escalation at runtime.
+#   - Caps CPU and memory to avoid resource exhaustion on a shared VPS.
+
+services:
+  botc:
+    restart: always
+    volumes:
+      - botc_data:/app/data
+      - botc_logs:/app/logs
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 512M
+
+volumes:
+  botc_data:
+  botc_logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+services:
+  botc:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: botc
+    restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      - ./data:/app/data
+      - ./logs:/app/logs
+    networks:
+      - botc_backend
+    command: ["python", "main.py"]
+
+  postgres:
+    image: postgres:16-alpine
+    container_name: botc-postgres
+    profiles: ["data"]
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-botc}
+      POSTGRES_USER: ${POSTGRES_USER:-botc}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change_me_in_env}
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+    networks:
+      - botc_backend
+
+  redis:
+    image: redis:7.2-alpine
+    container_name: botc-redis
+    profiles: ["data"]
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes", "--save", "60", "1000"]
+    volumes:
+      - redis_data:/data
+    ports:
+      - "6379:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+      start_period: 5s
+    networks:
+      - botc_backend
+
+volumes:
+  pg_data:
+  redis_data:
+
+networks:
+  botc_backend:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,11 @@ services:
     environment:
       POSTGRES_DB: ${POSTGRES_DB:-botc}
       POSTGRES_USER: ${POSTGRES_USER:-botc}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change_me_in_env}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - pg_data:/var/lib/postgresql/data
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,6 @@ services:
     command: ["redis-server", "--appendonly", "yes", "--save", "60", "1000"]
     volumes:
       - redis_data:/data
-    ports:
-      - "6379:6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s


### PR DESCRIPTION
Closes #11

Implements Phase 1 containerization for the project by introducing a Docker-based runtime and Docker Compose orchestration, plus documentation and environment templates to support running the bot and analysis scripts without a host Python setup.

## Changes

- **`Dockerfile`**: Multi-stage build (builder venv + slim runtime) to run `main.py` in a container. UTF-16 conversion step removed as `requirements.txt` is now UTF-8.
- **`docker-compose.yml`**: Base file for **local development** — bind-mounts `./data` and `./logs` for easy host inspection. Postgres bound to `127.0.0.1` only; Redis port not published by default.
- **`docker-compose.prod.yml`**: New **production override** for Linux VPS deployment — replaces bind-mounts with named volumes (fixes non-root user ownership issues), enforces `restart: always`, adds `no-new-privileges` security option, and caps CPU/memory.
- **`.dockerignore`** and **`.env.example`**: Standard ignores and environment template.
- **`README.md`**: Quick Start split into **Development** and **Production (Linux VPS)** subsections, with a table explaining which Compose file to use and the exact commands for each environment.