### PR TITLE
feat: Phase 1 — dynamic per-pair configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Offline analysis tools exposed as authenticated HTTP endpoints on the `botc` ser
 
 ### Database (`core/database.py`)
 
-Six ORM models: `OHLCData`, `TrailingState`, `ClosedPosition`, `BotControl`, `OptimizerJob`, `SessionRecord`. Direct SQLAlchemy (no async). All DAL functions are at module level (not a class). Migrations live in `scripts/migrations/versions/` managed by Alembic (`alembic.ini` points there).
+Seven ORM models: `OHLCData`, `TrailingState`, `ClosedPosition`, `BotControl`, `OptimizerJob`, `SessionRecord`, `PairConfig`. Direct SQLAlchemy (no async). All DAL functions are at module level (not a class). Migrations live in `scripts/migrations/versions/` managed by Alembic (`alembic.ini` points there).
 
 When changing an ORM model's table constraints, update **both** the model in `core/database.py` and the corresponding Alembic migration — they are not auto-synced, and CI builds the schema from migrations (a drift between the two recently allowed an invalid `mode` to pass the model but fail the migration's check constraint).
 
@@ -111,6 +111,8 @@ When changing an ORM model's table constraints, update **both** the model in `co
 `SessionRecord` is written once at the start of every `trading_session()` call (status `running`) and updated in the `finally` block with the final status, balance snapshot, per-pair market data, and captured log lines. It is the primary data source for the Grafana Sessions row.
 
 `OptimizerJob` backs the async optimizer (`optimizer_jobs` table). A row is inserted `running` by `JobStore.try_start` and updated to `completed` (with the JSONB result) or `failed`. A `ck_opt_jobs_mode_valid` check constraint restricts `mode` to `OPTIMIZE`/`CURRENT`/`AUTO`; `ck_opt_jobs_status_valid` restricts `status` to `running`/`completed`/`failed`.
+
+`PairConfig` (`pair_config` table) — DB-authoritative per-pair config, seeded once from `.env` on first boot. Holds `target_pct`, `hodl_pct`, `k_act`, `min_margin`, and the five `stop_pct_<level>` values per pair. Managed by `core/config_store.py`; editable at runtime via `PATCH /config/{pair}` and Telegram `/setconfig`.
 
 ### Exchange wrapper (`exchange/kraken.py`)
 
@@ -125,8 +127,8 @@ Rate-limited to 1 call/second via a module-level lock. `_safe_call` wraps every 
 Per-pair parameters are loaded from env vars by `core/config.py` into the `TRADING_PARAMS` dict. The key pattern:
 
 - `PAIR_TARGET_PCT` / `PAIR_HODL_PCT`: Portfolio allocation (inventory manager)
-- `PAIR_K_ACT` (or `PAIR_SELL_K_ACT` / `PAIR_BUY_K_ACT`): Activation ATR multiplier; `0` = immediate activation
-- `PAIR_MIN_MARGIN`: Minimum price margin from entry, expressed as fraction of entry price
+- `PAIR_K_ACT`: Activation ATR multiplier; `0` = immediate activation (single per pair — per-side `PAIR_SELL_K_ACT` / `PAIR_BUY_K_ACT` variants have been removed)
+- `PAIR_MIN_MARGIN`: Minimum price margin from entry, expressed as fraction of entry price (single per pair — per-side `PAIR_SELL_MIN_MARGIN` / `PAIR_BUY_MIN_MARGIN` variants have been removed)
 - `PAIR_STOP_PCT_LL` … `_HH`: K-stop percentile per volatility level
 
 ## Design choices
@@ -151,6 +153,9 @@ Non-obvious decisions a reviewer would otherwise question. Update this list when
 - **`telegram` runs as a separate service, not inside `botc`.** PTB's `Application.run_polling()` blocks its thread indefinitely. Co-locating it with the scheduler would risk a dropped Telegram connection stalling the trading loop. A separate service means the trading engine is entirely unaffected by Telegram's availability.
 - **`_SessionLogCollector` attaches to the root logger rather than threading a context object.** The alternative — passing a log buffer through the call graph (`trading_session` → `positions_manager` → `market_analyzer` → …) — would require modifying every function signature. The root-logger approach captures records from every module called during the session with zero changes to any call site.
 - **`sessions.log_messages` is `Text` (JSON string), not `JSONB`.** `balance` and `pair_data` use `JSONB` because Grafana queries them with SQL operators (`->>`, `jsonb_array_elements`). `log_messages` is always fetched as a whole array, never queried by individual entry — `Text` avoids `JSONB` parse overhead with no query trade-off at this access pattern.
+- **Dynamic pair config is DB-authoritative, seeded once from `.env`.** A dedicated typed `pair_config` table was chosen over the generic `BotControl` store because typed columns enable schema-level validation, clean ORM access, and straightforward `PATCH` semantics. `.env` remains the deployment-time seed for new installs; after first boot it is no longer read for these parameters. This lets an operator tune live via the API or Telegram without touching `.env` or restarting the container.
+- **`stop_pct` changes recalc `K_STOP` at the next session via a runtime dirty flag.** `apply_patch` in `core/config_store.py` sets a per-pair dirty flag in `core/runtime.py` when any `stop_pct` field changes. The scheduler checks the flag at the start of the next `trading_session()` and re-runs `calculate_trading_parameters` before the position block. This keeps heavy calibration (pivot detection, ATR percentiles) inside the scheduler thread and off the request path, avoiding any latency spike on the `PATCH` endpoint.
+- **`k_act`/`min_margin` are single per pair; `K_STOP` stays per-side.** The per-side `PAIR_SELL_K_ACT` / `PAIR_BUY_K_ACT` and `PAIR_SELL_MIN_MARGIN` / `PAIR_BUY_MIN_MARGIN` env vars were removed because the optimizer already treated these as single values and per-side tuning added config complexity without observable benefit. `K_STOP` is kept per-side (buy/sell) because it is a *derived* structural parameter (computed from pivot analysis), not a directly configured one, and the buy/sell paths naturally produce different stop distances.
 
 ## Testing conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ Rate-limited to 1 call/second via a module-level lock. `_safe_call` wraps every 
 
 ## Configuration
 
-Per-pair parameters are loaded from env vars by `core/config.py` into the `TRADING_PARAMS` dict. The key pattern:
+Per-pair parameters are loaded from env vars by `core/config.py` into the `TRADING_PARAMS` dict on startup. Since Phase 1, these values are also persisted in the `pair_config` DB table (seeded from `.env` on first boot via `config_store.load_or_seed()`); the DB is now the authoritative source and parameters can be changed at runtime via `PATCH /config/{pair}` without a restart. The key pattern:
 
 - `PAIR_TARGET_PCT` / `PAIR_HODL_PCT`: Portfolio allocation (inventory manager)
 - `PAIR_K_ACT`: Activation ATR multiplier; `0` = immediate activation (single per pair — per-side `PAIR_SELL_K_ACT` / `PAIR_BUY_K_ACT` variants have been removed)

--- a/api/app.py
+++ b/api/app.py
@@ -10,9 +10,10 @@ from fastapi import Depends, FastAPI, HTTPException, Request, Security
 from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyHeader
 
+import core.config_store as config_store
 import core.database as db
 from api.routes import backtest as backtest_route
-from api.routes import balance, control, market, positions, status
+from api.routes import balance, config, control, market, positions, status
 from api.routes import optimizer as optimizer_route
 from core.config import ALLOW_NO_AUTH, API_SECRET_TOKEN, SLEEPING_INTERVAL
 from core.scheduler import trading_session
@@ -46,6 +47,7 @@ async def lifespan(app: FastAPI):
         raise RuntimeError("Configuration validation failed — check logs for details")
     if not db.check_database_connection():
         raise RuntimeError("Cannot connect to PostgreSQL")
+    config_store.load_or_seed()
 
     scheduler = AsyncIOScheduler(
         executors={"default": ThreadPoolExecutor(max_workers=1)},
@@ -84,5 +86,5 @@ def health():
     return {"ok": True}
 
 
-for _r in (balance, control, market, positions, status, backtest_route, optimizer_route):
+for _r in (balance, config, control, market, positions, status, backtest_route, optimizer_route):
     app.include_router(_r.router, dependencies=_auth)

--- a/api/routes/config.py
+++ b/api/routes/config.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter, HTTPException
+
+import core.config_store as config_store
+from api.schemas import PairConfig, PairConfigPatch
+from core.config import PAIRS
+
+router = APIRouter(tags=["config"])
+
+
+def _to_model(pair: str, flat: dict) -> PairConfig:
+    return PairConfig(pair=pair, **flat)
+
+
+@router.get("/config", response_model=list[PairConfig])
+def get_config() -> list[PairConfig]:
+    return [_to_model(pair, flat) for pair, flat in config_store.get_all().items()]
+
+
+@router.get("/config/{pair}", response_model=PairConfig)
+def get_config_pair(pair: str) -> PairConfig:
+    if pair not in PAIRS:
+        raise HTTPException(status_code=404, detail=f"Unknown pair: {pair}")
+    return _to_model(pair, config_store.get_pair(pair))
+
+
+@router.patch("/config/{pair}", response_model=PairConfig)
+def patch_config_pair(pair: str, patch: PairConfigPatch) -> PairConfig:
+    if pair not in PAIRS:
+        raise HTTPException(status_code=404, detail=f"Unknown pair: {pair}")
+    fields = patch.model_dump(exclude_unset=True)
+    if not fields:
+        raise HTTPException(status_code=422, detail="No fields to update")
+    try:
+        typed = config_store.apply_patch(pair, fields, updated_by="api")
+    except config_store.ConfigValidationError as e:
+        raise HTTPException(status_code=422, detail="; ".join(e.errors)) from e
+    return _to_model(pair, typed)

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class MarketItem(BaseModel):
@@ -244,3 +244,33 @@ class OptimizerJobStatusResponse(BaseModel):
     created_at: datetime
     started_at: datetime | None = None
     finished_at: datetime | None = None
+
+
+class PairConfig(BaseModel):
+    pair: str
+    target_pct: float
+    hodl_pct: float
+    k_act: float | None = None
+    min_margin: float
+    stop_pct_ll: float
+    stop_pct_lv: float
+    stop_pct_mv: float
+    stop_pct_hv: float
+    stop_pct_hh: float
+
+
+class PairConfigPatch(BaseModel):
+    """Partial update. Unset fields are ignored; an explicit null k_act switches
+    the pair to the K_STOP + MIN_MARGIN activation path."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_pct: float | None = Field(default=None, ge=0, le=100)
+    hodl_pct: float | None = Field(default=None, ge=0, le=100)
+    k_act: float | None = Field(default=None, ge=0)
+    min_margin: float | None = Field(default=None, ge=0)
+    stop_pct_ll: float | None = Field(default=None, ge=0, le=1)
+    stop_pct_lv: float | None = Field(default=None, ge=0, le=1)
+    stop_pct_mv: float | None = Field(default=None, ge=0, le=1)
+    stop_pct_hv: float | None = Field(default=None, ge=0, le=1)
+    stop_pct_hh: float | None = Field(default=None, ge=0, le=1)

--- a/core/config.py
+++ b/core/config.py
@@ -58,18 +58,13 @@ STOP_PCT_DEFAULT = 0.90  # Fallback STOP_PCT if not set for a level
 
 
 # Trading params
-def _build_trading_params() -> dict[str, dict[str, dict[str, Any]]]:
+def _build_trading_params() -> dict[str, dict[str, Any]]:
     params = {}
     for pair in PAIRS:
         params[pair] = {
-            "sell": {
-                "K_ACT": os.getenv(f"{pair}_SELL_K_ACT", os.getenv(f"{pair}_K_ACT")),
-                "MIN_MARGIN": os.getenv(f"{pair}_SELL_MIN_MARGIN", os.getenv(f"{pair}_MIN_MARGIN")),
-            },
-            "buy": {
-                "K_ACT": os.getenv(f"{pair}_BUY_K_ACT", os.getenv(f"{pair}_K_ACT")),
-                "MIN_MARGIN": os.getenv(f"{pair}_BUY_MIN_MARGIN", os.getenv(f"{pair}_MIN_MARGIN")),
-            },
+            "K_ACT": os.getenv(f"{pair}_K_ACT"),
+            "MIN_MARGIN": os.getenv(f"{pair}_MIN_MARGIN"),
+            "K_STOP": {"buy": {}, "sell": {}},
         }
     return params
 
@@ -106,3 +101,27 @@ def _build_percentiles() -> dict[str, dict[str, Any]]:
 
 
 STOP_PERCENTILES = _build_percentiles()
+
+
+# Flat config view <-> live dicts. The "flat" dict uses the keys
+# target_pct, hodl_pct, k_act, min_margin, stop_pct_ll..stop_pct_hh and is the
+# representation shared by validation, the config store, and the API.
+def set_pair_config(pair: str, typed: dict[str, Any]) -> None:
+    TRADING_PARAMS[pair]["K_ACT"] = typed["k_act"]
+    TRADING_PARAMS[pair]["MIN_MARGIN"] = typed["min_margin"]
+    ASSET_ALLOCATION[pair]["TARGET_PCT"] = typed["target_pct"]
+    ASSET_ALLOCATION[pair]["HODL_PCT"] = typed["hodl_pct"]
+    for lvl in VOLATILITY_LEVELS:
+        STOP_PERCENTILES[pair][lvl] = typed[f"stop_pct_{lvl.lower()}"]
+
+
+def get_pair_config(pair: str) -> dict[str, Any]:
+    flat = {
+        "k_act": TRADING_PARAMS[pair]["K_ACT"],
+        "min_margin": TRADING_PARAMS[pair]["MIN_MARGIN"],
+        "target_pct": ASSET_ALLOCATION[pair]["TARGET_PCT"],
+        "hodl_pct": ASSET_ALLOCATION[pair]["HODL_PCT"],
+    }
+    for lvl in VOLATILITY_LEVELS:
+        flat[f"stop_pct_{lvl.lower()}"] = STOP_PERCENTILES[pair][lvl]
+    return flat

--- a/core/config_store.py
+++ b/core/config_store.py
@@ -16,6 +16,26 @@ import core.runtime as runtime
 from core.config import PAIRS, VOLATILITY_LEVELS
 from core.validation import normalize_pair_config, target_sum_error
 
+# Column precisions from the pair_config migration (Numeric scale values).
+_SCALE = {
+    "target_pct": 3,
+    "hodl_pct": 3,
+    "k_act": 4,
+    "min_margin": 8,
+    **{f"stop_pct_{lvl.lower()}": 3 for lvl in VOLATILITY_LEVELS},
+}
+
+
+def _round_to_db_precision(typed: dict[str, Any]) -> dict[str, Any]:
+    rounded = {}
+    for k, v in typed.items():
+        if k in _SCALE and v is not None:
+            rounded[k] = round(float(v), _SCALE[k])
+        else:
+            rounded[k] = v
+    return rounded
+
+
 _lock = threading.Lock()
 
 # The flat config keys persisted in pair_config and exchanged with the API.
@@ -76,6 +96,23 @@ def apply_patch(pair: str, fields: dict[str, Any], updated_by: str | None = None
             raise UnknownPairError(pair)
 
         current = config.get_pair_config(pair)
+
+        # When switching k_act from set to null, require an explicit min_margin
+        # if the current value is 0 (auto-zeroed in k_act-active mode).
+        if (
+            "k_act" in fields
+            and fields["k_act"] is None
+            and current.get("k_act") is not None
+            and "min_margin" not in fields
+            and float(current.get("min_margin") or 0) == 0.0
+        ):
+            raise ConfigValidationError(
+                [
+                    f"{pair}: min_margin must be provided when setting k_act to null "
+                    f"(current min_margin is 0, which was set automatically while k_act was active)"
+                ]
+            )
+
         merged = {**current, **fields}
         typed, errors = normalize_pair_config(pair, merged)
 
@@ -87,6 +124,8 @@ def apply_patch(pair: str, fields: dict[str, Any], updated_by: str | None = None
 
         if errors:
             raise ConfigValidationError(errors)
+
+        typed = _round_to_db_precision(typed)
 
         stop_changed = any(
             typed[f"stop_pct_{lvl.lower()}"] != current[f"stop_pct_{lvl.lower()}"] for lvl in VOLATILITY_LEVELS

--- a/core/config_store.py
+++ b/core/config_store.py
@@ -1,0 +1,100 @@
+"""Single owner of dynamic per-pair configuration.
+
+The live module-level dicts in ``core.config`` (TRADING_PARAMS, ASSET_ALLOCATION,
+STOP_PERCENTILES) remain the read path for the trading loop. This module keeps
+them current: it seeds them from the DB (or seeds the DB from them) at startup,
+and applies validated runtime patches. A module lock makes each multi-field patch
+atomic against the scheduler's reads.
+"""
+
+import threading
+from typing import Any
+
+import core.config as config
+import core.database as db
+import core.runtime as runtime
+from core.config import PAIRS, VOLATILITY_LEVELS
+from core.validation import normalize_pair_config, target_sum_error
+
+_lock = threading.Lock()
+
+# The flat config keys persisted in pair_config and exchanged with the API.
+FLAT_KEYS = (
+    "target_pct",
+    "hodl_pct",
+    "k_act",
+    "min_margin",
+    *[f"stop_pct_{lvl.lower()}" for lvl in VOLATILITY_LEVELS],
+)
+
+
+class UnknownPairError(Exception):
+    """Raised when a config operation targets a pair not in PAIRS."""
+
+
+class ConfigValidationError(Exception):
+    """Raised when a patch fails validation. Carries the list of error strings."""
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        super().__init__("; ".join(errors))
+
+
+def _flat_from_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {k: row[k] for k in FLAT_KEYS}
+
+
+def get_pair(pair: str) -> dict[str, Any]:
+    """Current typed flat config for one pair, read from the live dicts."""
+    return config.get_pair_config(pair)
+
+
+def get_all() -> dict[str, dict[str, Any]]:
+    return {pair: config.get_pair_config(pair) for pair in PAIRS}
+
+
+def load_or_seed() -> None:
+    """Startup sync. For each pair: load the DB row into the live dicts if present,
+    otherwise seed a row from the (already env-validated) live dict values."""
+    rows = db.load_all_pair_config()
+    for pair in PAIRS:
+        if pair in rows:
+            config.set_pair_config(pair, _flat_from_row(rows[pair]))
+        else:
+            db.upsert_pair_config(pair, config.get_pair_config(pair), updated_by="seed")
+
+
+def apply_patch(pair: str, fields: dict[str, Any], updated_by: str | None = None) -> dict[str, Any]:
+    """Validate, persist, and apply a partial config change for one pair.
+
+    Returns the new typed flat config. Raises UnknownPairError for an unknown
+    pair, ConfigValidationError on validation failure (nothing persisted or
+    applied). Persist-then-apply: if the DB write fails the live dicts are
+    untouched (the exception propagates)."""
+    with _lock:
+        if pair not in PAIRS:
+            raise UnknownPairError(pair)
+
+        current = config.get_pair_config(pair)
+        merged = {**current, **fields}
+        typed, errors = normalize_pair_config(pair, merged)
+
+        targets = {p: config.get_pair_config(p)["target_pct"] for p in PAIRS if p != pair}
+        targets[pair] = typed["target_pct"]
+        sum_err = target_sum_error(targets)
+        if sum_err:
+            errors.append(sum_err)
+
+        if errors:
+            raise ConfigValidationError(errors)
+
+        stop_changed = any(
+            typed[f"stop_pct_{lvl.lower()}"] != current[f"stop_pct_{lvl.lower()}"] for lvl in VOLATILITY_LEVELS
+        )
+
+        db.upsert_pair_config(pair, typed, updated_by=updated_by)
+        config.set_pair_config(pair, typed)
+        if stop_changed:
+            runtime.mark_config_dirty(pair)
+
+        return typed

--- a/core/database.py
+++ b/core/database.py
@@ -263,6 +263,58 @@ class BotControl(Base):
         }
 
 
+class PairConfig(Base):
+    """Per-pair dynamic trading configuration (DB-authoritative, seeded from env)."""
+
+    __tablename__ = "pair_config"
+
+    pair = Column(Text, primary_key=True, nullable=False)
+    target_pct = Column(Numeric(6, 3), nullable=False, default=0)
+    hodl_pct = Column(Numeric(6, 3), nullable=False, default=0)
+    k_act = Column(Numeric(10, 4), nullable=True)
+    min_margin = Column(Numeric(12, 8), nullable=False, default=0)
+    stop_pct_ll = Column(Numeric(4, 3), nullable=False, default=0.90)
+    stop_pct_lv = Column(Numeric(4, 3), nullable=False, default=0.90)
+    stop_pct_mv = Column(Numeric(4, 3), nullable=False, default=0.90)
+    stop_pct_hv = Column(Numeric(4, 3), nullable=False, default=0.90)
+    stop_pct_hh = Column(Numeric(4, 3), nullable=False, default=0.90)
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+    updated_by = Column(Text, nullable=True)
+
+    __table_args__ = (
+        CheckConstraint("target_pct >= 0 AND target_pct <= 100", name="ck_pair_config_target_pct_range"),
+        CheckConstraint("hodl_pct >= 0 AND hodl_pct <= 100", name="ck_pair_config_hodl_pct_range"),
+        CheckConstraint("k_act IS NULL OR k_act >= 0", name="ck_pair_config_k_act_nonneg"),
+        CheckConstraint("min_margin >= 0", name="ck_pair_config_min_margin_nonneg"),
+        CheckConstraint("stop_pct_ll >= 0 AND stop_pct_ll <= 1", name="ck_pair_config_stop_ll_range"),
+        CheckConstraint("stop_pct_lv >= 0 AND stop_pct_lv <= 1", name="ck_pair_config_stop_lv_range"),
+        CheckConstraint("stop_pct_mv >= 0 AND stop_pct_mv <= 1", name="ck_pair_config_stop_mv_range"),
+        CheckConstraint("stop_pct_hv >= 0 AND stop_pct_hv <= 1", name="ck_pair_config_stop_hv_range"),
+        CheckConstraint("stop_pct_hh >= 0 AND stop_pct_hh <= 1", name="ck_pair_config_stop_hh_range"),
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pair": self.pair,
+            "target_pct": float(self.target_pct),
+            "hodl_pct": float(self.hodl_pct),
+            "k_act": float(self.k_act) if self.k_act is not None else None,
+            "min_margin": float(self.min_margin),
+            "stop_pct_ll": float(self.stop_pct_ll),
+            "stop_pct_lv": float(self.stop_pct_lv),
+            "stop_pct_mv": float(self.stop_pct_mv),
+            "stop_pct_hv": float(self.stop_pct_hv),
+            "stop_pct_hh": float(self.stop_pct_hh),
+            "updated_at": self.updated_at,
+            "updated_by": self.updated_by,
+        }
+
+
 class OptimizerJob(Base):
     """Optimizer job state and results."""
 
@@ -691,6 +743,29 @@ def get_bot_paused() -> bool:
 def set_bot_paused(paused: bool, updated_by: str | None = None) -> None:
     """Set bot paused state in bot_control table."""
     set_control_value("bot_paused", "true" if paused else "false", updated_by=updated_by)
+
+
+# ============================================================================
+# Pair Config Operations
+# ============================================================================
+
+
+def load_all_pair_config() -> dict[str, dict[str, Any]]:
+    """Return {pair: pair_config_dict} for all stored pairs."""
+    try:
+        with get_session() as session:
+            return {row.pair: row.to_dict() for row in session.query(PairConfig).all()}
+    except Exception as e:
+        logger.error(f"Error loading pair_config: {e}")
+        return {}
+
+
+def upsert_pair_config(pair: str, values: dict[str, Any], updated_by: str | None = None) -> None:
+    """Insert or update one pair's config row. ``values`` is a flat typed dict
+    with keys target_pct, hodl_pct, k_act, min_margin, stop_pct_ll..stop_pct_hh."""
+    with get_session() as session:
+        session.merge(PairConfig(pair=pair, updated_by=updated_by, **values))
+    logger.debug(f"Saved pair_config for {pair}")
 
 
 # ============================================================================

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -17,6 +17,7 @@ _shared_data = {
     #   "computed_at": datetime,
     # }}
     # Phase 11 extends this entry with "window_days" + "window_sweep".
+    "config_dirty": set(),  # pairs whose config changed since the last scheduler check
 }
 
 
@@ -89,3 +90,17 @@ def get_pair_calibration(pair: str) -> dict[str, Any] | None:
     with _lock:
         entry = _shared_data["pair_calibration"].get(pair)
         return None if entry is None else dict(entry)  # shallow copy, matches existing pattern
+
+
+def mark_config_dirty(pair: str) -> None:
+    with _lock:
+        _shared_data["config_dirty"].add(pair)
+
+
+def pop_config_dirty(pair: str) -> bool:
+    """Return True (and clear) if pair's config changed since the last check."""
+    with _lock:
+        if pair in _shared_data["config_dirty"]:
+            _shared_data["config_dirty"].discard(pair)
+            return True
+        return False

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -90,7 +90,7 @@ def trading_session() -> None:
                 logging.error("Could not fetch price or ATR. Skipping this pair.")
                 continue
 
-            if _session_count % PARAM_SESSIONS == 0:
+            if _session_count % PARAM_SESSIONS == 0 or runtime.pop_config_dirty(pair):
                 calculate_trading_parameters(pair)
 
             vol_level = get_volatility_level(pair, current_atr)

--- a/core/validation.py
+++ b/core/validation.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any
 
+import core.config as config
 from core.config import (
     ALLOW_NO_AUTH,
     API_SECRET_TOKEN,
@@ -90,73 +91,72 @@ def _parse_float(
     return f
 
 
-def validate_pair_params(errors: list[str]) -> None:
-    """Validate and normalize per-pair trading parameters.
+def normalize_pair_config(pair: str, raw: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Validate + normalize one pair's flat config.
 
+    ``raw`` keys: k_act, min_margin, target_pct, hodl_pct, stop_pct_ll..stop_pct_hh
+    (values may be strings, floats, or None). Returns (typed_flat, errors).
     Rules:
-    - K_ACT: float, or unset/empty (treated as None — fall through to K_STOP+MIN_MARGIN path).
-    - MIN_MARGIN: only required (must be float) when K_ACT is None.
-    - TARGET_PCT: float in [0, 100]; the sum across pairs must also be <= 100.
-    - HODL_PCT: float in [0, 100].
-    - STOP_PCT_<level>: float in [0, 1] or unset (default 0.90).
-
-    On success, writes normalized typed values back into TRADING_PARAMS,
-    ASSET_ALLOCATION and STOP_PERCENTILES so consumers always see floats/None.
+    - k_act: float >= 0, or None (falls through to K_STOP + MIN_MARGIN path).
+    - min_margin: float >= 0; required when k_act is None; normalized to 0.0 when
+      k_act is set.
+    - target_pct, hodl_pct: float in [0, 100] (default 0.0 when unset).
+    - stop_pct_<level>: float in [0, 1] (default STOP_PCT_DEFAULT when unset).
+    The cross-pair target sum is checked separately by target_sum_error.
     """
-    total_target = 0.0
-    for pair in PAIRS:
-        for side in ("sell", "buy"):
-            side_label = side.upper()
+    errors: list[str] = []
+    out: dict[str, Any] = {}
 
-            k_act = _parse_float(
-                TRADING_PARAMS[pair][side]["K_ACT"],
-                f"{pair}_{side_label}_K_ACT",
-                errors,
-            )
-            TRADING_PARAMS[pair][side]["K_ACT"] = k_act
+    k_act = _parse_float(raw.get("k_act"), f"{pair}_K_ACT", errors, min_val=0)
+    out["k_act"] = k_act
 
-            min_margin_raw = TRADING_PARAMS[pair][side]["MIN_MARGIN"]
-            if k_act is None:
-                min_margin = _parse_float(min_margin_raw, f"{pair}_{side_label}_MIN_MARGIN", errors)
-                if min_margin is None and min_margin_raw in (None, ""):
-                    errors.append(f"{pair}_{side_label}_MIN_MARGIN is required when K_ACT is not set")
-                TRADING_PARAMS[pair][side]["MIN_MARGIN"] = min_margin
-            else:
-                # K_ACT defined — MIN_MARGIN unused. Normalize to a float if parseable, else 0.
-                parsed = _parse_float(min_margin_raw, f"{pair}_{side_label}_MIN_MARGIN", [])
-                TRADING_PARAMS[pair][side]["MIN_MARGIN"] = parsed if parsed is not None else 0.0
+    mm_raw = raw.get("min_margin")
+    if k_act is None:
+        min_margin = _parse_float(mm_raw, f"{pair}_MIN_MARGIN", errors, min_val=0)
+        if min_margin is None and mm_raw in (None, ""):
+            errors.append(f"{pair}_MIN_MARGIN is required when K_ACT is not set")
+        out["min_margin"] = min_margin
+    else:
+        parsed = _parse_float(mm_raw, f"{pair}_MIN_MARGIN", [], min_val=0)
+        out["min_margin"] = parsed if parsed is not None else 0.0
 
-        target_pct = _parse_float(
-            ASSET_ALLOCATION[pair]["TARGET_PCT"],
-            f"{pair}_TARGET_PCT",
-            errors,
-            min_val=0,
-            max_val=100,
-        )
-        ASSET_ALLOCATION[pair]["TARGET_PCT"] = target_pct if target_pct is not None else 0.0
-        total_target += ASSET_ALLOCATION[pair]["TARGET_PCT"]
+    target = _parse_float(raw.get("target_pct"), f"{pair}_TARGET_PCT", errors, min_val=0, max_val=100)
+    out["target_pct"] = target if target is not None else 0.0
 
-        hodl_pct = _parse_float(
-            ASSET_ALLOCATION[pair]["HODL_PCT"],
-            f"{pair}_HODL_PCT",
-            errors,
-            min_val=0,
-            max_val=100,
-        )
-        ASSET_ALLOCATION[pair]["HODL_PCT"] = hodl_pct if hodl_pct is not None else 0.0
+    hodl = _parse_float(raw.get("hodl_pct"), f"{pair}_HODL_PCT", errors, min_val=0, max_val=100)
+    out["hodl_pct"] = hodl if hodl is not None else 0.0
 
-        for level in VOLATILITY_LEVELS:
-            parsed = _parse_float(
-                STOP_PERCENTILES[pair][level],
-                f"{pair}_STOP_PCT_{level}",
-                errors,
-                min_val=0,
-                max_val=1,
-            )
-            STOP_PERCENTILES[pair][level] = parsed if parsed is not None else STOP_PCT_DEFAULT
+    for level in VOLATILITY_LEVELS:
+        key = f"stop_pct_{level.lower()}"
+        parsed = _parse_float(raw.get(key), f"{pair}_STOP_PCT_{level}", errors, min_val=0, max_val=1)
+        out[key] = parsed if parsed is not None else STOP_PCT_DEFAULT
 
-    if total_target > 100:
-        errors.append(f"Sum of TARGET_PCT across all pairs must not exceed 100 (got {total_target:g})")
+    return out, errors
+
+
+def target_sum_error(targets: dict[str, float]) -> str | None:
+    """Return an error string if the sum of target_pct across pairs exceeds 100."""
+    total = sum(targets.values())
+    if total > 100:
+        return f"Sum of TARGET_PCT across all pairs must not exceed 100 (got {total:g})"
+    return None
+
+
+def validate_pair_params(errors: list[str]) -> None:
+    """Validate and normalize per-pair trading parameters, writing typed values
+    back into the live dicts. Shares normalize_pair_config with the runtime
+    config store so startup and runtime apply identical rules."""
+    typed_targets: dict[str, float] = {}
+    for pair in config.PAIRS:
+        raw = config.get_pair_config(pair)
+        typed, errs = normalize_pair_config(pair, raw)
+        errors.extend(errs)
+        config.set_pair_config(pair, typed)
+        typed_targets[pair] = typed["target_pct"]
+
+    err = target_sum_error(typed_targets)
+    if err:
+        errors.append(err)
 
 
 def build_and_validate_pairs(errors: list[str]) -> None:

--- a/core/validation.py
+++ b/core/validation.py
@@ -5,7 +5,6 @@ import core.config as config
 from core.config import (
     ALLOW_NO_AUTH,
     API_SECRET_TOKEN,
-    ASSET_ALLOCATION,
     ATR_DESV_LIMIT,
     ATR_PERIOD,
     CANDLE_TIMEFRAME,
@@ -15,12 +14,10 @@ from core.config import (
     PARAM_SESSIONS,
     SLEEPING_INTERVAL,
     STOP_PCT_DEFAULT,
-    STOP_PERCENTILES,
     TELEGRAM_ENABLED,
     TELEGRAM_POLL_INTERVAL,
     TELEGRAM_TOKEN,
     TELEGRAM_USER_ID,
-    TRADING_PARAMS,
     VOLATILITY_LEVELS,
 )
 from exchange.kraken import build_pairs_map

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,14 +2,15 @@
 
 This is the active roadmap for BoTCoin. It continues from the **closed V2 milestone**, whose goal — evolving BoTCoin into a production-grade backend service with professional persistence, observability, and testability — was achieved across Phases 0–10. The frozen V2 record lives at [`v2/ROADMAP.md`](v2/ROADMAP.md).
 
-V3's overarching theme is still being formalized. This roadmap is currently seeded with the two items that were scoped under V2 but never built. Other work already in progress (e.g. Dynamic Configuration) will be folded in here once V3's direction is settled.
+V3's overarching theme is still being formalized. This roadmap is currently seeded with the items scoped under V2 but never built, plus Dynamic Pair Configuration as Phase 1.
 
 ---
 
 ## 📋 Table of Contents
 
 - [Phased Roadmap](#-phased-roadmap)
-  - [Phase 1 – Strategy Refinement: Trend/Chop Regime Filter](#phase-1--strategy-refinement-trendchop-regime-filter)
+  - [Phase 1 – Dynamic Pair Configuration](#phase-1--dynamic-pair-configuration)
+  - [Phase 2 – Strategy Refinement: Trend/Chop Regime Filter](#phase-2--strategy-refinement-trendchop-regime-filter)
 - [Appendix: Deferred Phases](#-appendix-deferred-phases)
   - [Auto-Lookback Window for K_STOP Calibration](#auto-lookback-window-for-k_stop-calibration)
 
@@ -19,7 +20,51 @@ V3's overarching theme is still being formalized. This roadmap is currently seed
 
 ---
 
-### Phase 1 – Strategy Refinement: Trend/Chop Regime Filter
+### Phase 1 – Dynamic Pair Configuration
+
+**Goal:** Make the pair-specific trading parameters currently fixed in `.env` —
+`target_pct`, `hodl_pct`, `k_act`, `min_margin`, and the volatility-based stop
+percentiles (`stop_pct_<level>`) — editable at runtime through both the HTTP API
+and Telegram, with changes taking effect automatically on the next bot session,
+no restart required. Ships with a cleanup: `k_act`/`min_margin` collapse from
+per-side to a single value per pair (`K_STOP` stays per-side, as it is derived).
+
+**Why:** These parameters are the main strategy knobs. Tuning any of them today
+requires editing `.env` and restarting `botc`, interrupting the trading loop.
+Exposing them through the existing API + Telegram surfaces (mirroring
+`/control/pause`) lets the operator retune live and apply optimizer
+recommendations without a redeploy. The per-side collapse removes an existing
+inconsistency — the optimizer already treats `k_act`/`min_margin` as single
+values.
+
+**Scope:** Full design at
+[`superpowers/specs/2026-06-16-dynamic-pair-config-design.md`](superpowers/specs/2026-06-16-dynamic-pair-config-design.md).
+
+- [ ] `pair_config` table (ORM model + Alembic migration); DB-authoritative,
+      seeded once from `.env`
+- [ ] `core/config_store.py` — load/seed at startup, typed reads, atomic
+      `apply_patch` that updates the live dicts
+- [ ] Per-pair dirty flag in `core/runtime.py`; `core/scheduler.py` recalcs
+      `K_STOP` at the next session when a `stop_pct` changes
+- [ ] `GET /config`, `GET /config/{pair}`, `PATCH /config/{pair}`
+      (`api/routes/config.py` + schemas)
+- [ ] Telegram `/config [pair]` and `/setconfig <pair> <field> <value>`
+- [ ] Collapse `k_act`/`min_margin` to single per-pair across config, validation,
+      `positions_manager`, `engine`, `optimizer`, `backtest`; drop
+      `PAIR_SELL_/BUY_` env vars; update `.env.example` + `docs/configuration.md`
+- [ ] Reusable `normalize_pair_config` shared by startup validation and runtime
+      patches (incl. cross-pair `target_pct` sum check)
+- [ ] Unit tests across store, validation, API, Telegram, scheduler, and the
+      collapse regression (80% gate)
+
+**Success criteria:** An operator can query and modify any pair-specific
+parameter via the API and Telegram; changes persist in `pair_config` and take
+effect on the next session without a restart; `.env` seeds config only on first
+boot; `k_act`/`min_margin` are single per pair everywhere.
+
+---
+
+### Phase 2 – Strategy Refinement: Trend/Chop Regime Filter
 
 **Goal:** Add a Choppiness Index–based regime classifier that gates new position entries during sideways markets while leaving the trailing-stop exit logic untouched. The filter reuses the existing OHLC + ATR pipeline, introduces no new external dependencies, and ships in two stages — observation first, enforcement second — so behavior changes are validated against live data before being enabled.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -38,7 +38,7 @@ inconsistency — the optimizer already treats `k_act`/`min_margin` as single
 values.
 
 **Scope:** Full design at
-[`superpowers/specs/2026-06-16-dynamic-pair-config-design.md`](superpowers/specs/2026-06-16-dynamic-pair-config-design.md).
+[`specs/dynamic-pair-config-design.md`](specs/dynamic-pair-config-design.md).
 
 - [ ] `pair_config` table (ORM model + Alembic migration); DB-authoritative,
       seeded once from `.env`

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -40,21 +40,21 @@ values.
 **Scope:** Full design at
 [`specs/dynamic-pair-config-design.md`](specs/dynamic-pair-config-design.md).
 
-- [ ] `pair_config` table (ORM model + Alembic migration); DB-authoritative,
+- [x] `pair_config` table (ORM model + Alembic migration); DB-authoritative,
       seeded once from `.env`
-- [ ] `core/config_store.py` — load/seed at startup, typed reads, atomic
+- [x] `core/config_store.py` — load/seed at startup, typed reads, atomic
       `apply_patch` that updates the live dicts
-- [ ] Per-pair dirty flag in `core/runtime.py`; `core/scheduler.py` recalcs
+- [x] Per-pair dirty flag in `core/runtime.py`; `core/scheduler.py` recalcs
       `K_STOP` at the next session when a `stop_pct` changes
-- [ ] `GET /config`, `GET /config/{pair}`, `PATCH /config/{pair}`
+- [x] `GET /config`, `GET /config/{pair}`, `PATCH /config/{pair}`
       (`api/routes/config.py` + schemas)
-- [ ] Telegram `/config [pair]` and `/setconfig <pair> <field> <value>`
-- [ ] Collapse `k_act`/`min_margin` to single per-pair across config, validation,
+- [x] Telegram `/config [pair]` and `/setconfig <pair> <field> <value>`
+- [x] Collapse `k_act`/`min_margin` to single per-pair across config, validation,
       `positions_manager`, `engine`, `optimizer`, `backtest`; drop
       `PAIR_SELL_/BUY_` env vars; update `.env.example` + `docs/configuration.md`
-- [ ] Reusable `normalize_pair_config` shared by startup validation and runtime
+- [x] Reusable `normalize_pair_config` shared by startup validation and runtime
       patches (incl. cross-pair `target_pct` sum check)
-- [ ] Unit tests across store, validation, API, Telegram, scheduler, and the
+- [x] Unit tests across store, validation, API, Telegram, scheduler, and the
       collapse regression (80% gate)
 
 **Success criteria:** An operator can query and modify any pair-specific

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,10 +69,8 @@ For each pair listed in `PAIRS`, define the following variables by replacing `PA
 |---|---|---|---|
 | `PAIR_TARGET_PCT` | yes | — | Target portfolio allocation for this asset as a percentage of total portfolio value |
 | `PAIR_HODL_PCT` | yes | — | Minimum hold threshold; the bot does not sell below this percentage |
-| `PAIR_K_ACT` | no | — | ATR multiplier for activation price distance. If omitted, `K_STOP × ATR + MIN_MARGIN × entry_price` is used instead |
-| `PAIR_SELL_K_ACT` / `PAIR_BUY_K_ACT` | no | — | Per-side overrides for `K_ACT` |
-| `PAIR_MIN_MARGIN` | no | — | Minimum profit margin from entry price as a fraction (e.g. `0.009` = 0.9 %). Used only when `K_ACT` is not set |
-| `PAIR_SELL_MIN_MARGIN` / `PAIR_BUY_MIN_MARGIN` | no | — | Per-side overrides for `MIN_MARGIN` |
+| `PAIR_K_ACT` | no | — | ATR multiplier for activation price distance (single per pair — no per-side variants). If omitted, `K_STOP × ATR + MIN_MARGIN × entry_price` is used instead |
+| `PAIR_MIN_MARGIN` | no | — | Minimum profit margin from entry price as a fraction (e.g. `0.009` = 0.9 %; single per pair — no per-side variants). Used only when `K_ACT` is not set |
 | `PAIR_STOP_PCT_LL` | yes | — | K_STOP percentile for Very Low Volatility (LL) regime |
 | `PAIR_STOP_PCT_LV` | yes | — | K_STOP percentile for Low Volatility (LV) regime |
 | `PAIR_STOP_PCT_MV` | yes | — | K_STOP percentile for Medium Volatility (MV) regime |
@@ -80,6 +78,20 @@ For each pair listed in `PAIRS`, define the following variables by replacing `PA
 | `PAIR_STOP_PCT_HH` | yes | — | K_STOP percentile for Very High Volatility (HH) regime |
 
 See [trading-strategy.md](trading-strategy.md) for how K_STOP percentiles are derived and what values to choose.
+
+### DB-authoritative config (Phase 1)
+
+The parameters above (`TARGET_PCT`, `HODL_PCT`, `K_ACT`, `MIN_MARGIN`, `STOP_PCT_<level>`) are **DB-authoritative** once the bot has booted. On first boot `core/config_store.py` seeds the `pair_config` table from `.env`; subsequent boots read from the DB and `.env` values for these fields are ignored.
+
+To query or modify them at runtime without a restart:
+
+- `GET /config` — returns current config for all pairs
+- `GET /config/{pair}` — returns config for one pair
+- `PATCH /config/{pair}` — updates one or more fields for a pair (validated, persisted, applied immediately; `stop_pct` changes trigger `K_STOP` recalculation on the next scheduler session)
+
+Telegram equivalents: `/config [pair]` (read) and `/setconfig <pair> <field> <value>` (write).
+
+All REST endpoints require the `X-Api-Token` header (see [API authentication](#api-authentication)).
 
 ---
 

--- a/docs/plans/phase-1-dynamic-pair-config.md
+++ b/docs/plans/phase-1-dynamic-pair-config.md
@@ -1,0 +1,1402 @@
+# Phase 1 – Dynamic Pair Configuration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make per-pair trading parameters (`target_pct`, `hodl_pct`, `k_act`, `min_margin`, `stop_pct_<level>`) editable at runtime via the HTTP API and Telegram, persisted in PostgreSQL (DB-authoritative, seeded once from `.env`), with changes taking effect on the next bot session without a restart.
+
+**Architecture:** A new `pair_config` table is the source of truth, seeded from `.env` on first boot. A new `core/config_store.py` owns load/seed and atomic patches, keeping the existing live module-level dicts (`TRADING_PARAMS`, `ASSET_ALLOCATION`, `STOP_PERCENTILES`) current so consumers are unchanged. `k_act`/`min_margin` are read live each tick; `stop_pct` changes set a per-pair dirty flag that triggers a `K_STOP` recalc on the next scheduler session. Shipping alongside is a cleanup that collapses `k_act`/`min_margin` from per-side to a single value per pair (`K_STOP` stays per-side because it is derived).
+
+**Tech Stack:** Python 3.12, FastAPI, SQLAlchemy (sync) + Alembic, Pydantic v2, python-telegram-bot, pytest.
+
+**Spec:** [`../specs/dynamic-pair-config-design.md`](../specs/dynamic-pair-config-design.md)
+
+---
+
+## File structure
+
+**New files:**
+- `core/config_store.py` — single owner of dynamic config: `load_or_seed`, `get_pair`, `get_all`, `apply_patch`, `ConfigValidationError`, `UnknownPairError`.
+- `api/routes/config.py` — `GET /config`, `GET /config/{pair}`, `PATCH /config/{pair}`.
+- `scripts/migrations/versions/20260616_01_pair_config.py` — Alembic migration for the `pair_config` table.
+- `tests/unit/core/test_config_store.py`
+- `tests/unit/api/test_config_route.py`
+
+**Modified files:**
+- `core/config.py` — collapse `_build_trading_params`; add `set_pair_config` / `get_pair_config` dict helpers.
+- `core/validation.py` — extract `normalize_pair_config` + `target_sum_error`; rewrite `validate_pair_params`.
+- `core/database.py` — add `PairConfig` model + DAL (`load_all_pair_config`, `upsert_pair_config`).
+- `core/runtime.py` — per-pair config dirty flag.
+- `core/scheduler.py` — recalc on dirty flag.
+- `trading/engine.py` — remove `SidePolicy`; `EngineConfig` carries single `k_act`/`min_margin`.
+- `trading/parameters_manager.py` — `K_STOP` nested under `["K_STOP"][side]`.
+- `trading/positions_manager.py` — read pair-level `K_ACT`/`MIN_MARGIN`.
+- `trading/optimizer/search.py` — build `EngineConfig` with single values; `_candidate_from_env` reads pair-level.
+- `trading/backtest.py` — build `EngineConfig` with single values.
+- `api/schemas.py` — `PairConfig`, `PairConfigPatch`.
+- `api/app.py` — register config router; call `config_store.load_or_seed()` in lifespan.
+- `services/telegram/polling.py` — `/config`, `/setconfig`, help text, handler registration.
+- `.env.example`, `docs/configuration.md`, `CLAUDE.md`, `docs/ROADMAP.md` — docs + env cleanup.
+
+**Modified tests (collapse regression):** `tests/unit/trading/test_engine.py`, `test_backtest.py`, `test_positions_manager.py`, `test_parameters_manager.py`, `tests/unit/optimizer/test_search.py`, `tests/unit/core/test_validation.py`, `tests/unit/services/test_telegram.py`, `tests/unit/core/test_scheduler.py`.
+
+**Commands** (run from repo root; `PYTHONPATH=.` is required):
+- Single test: `PYTHONPATH=. pytest tests/unit/path::test_name -v`
+- Full unit suite + lint: `PYTHONPATH=. pytest tests/unit/ && python -m ruff check . && python -m ruff format --check .`
+
+---
+
+## Task 1: Collapse k_act/min_margin to a single per-pair value
+
+This is a coordinated structural change to `TRADING_PARAMS[pair]`. It is committed as one unit because the dict shape changes across all consumers at once. Target shape:
+
+```python
+TRADING_PARAMS[pair] = {
+    "K_ACT": float | None,
+    "MIN_MARGIN": float,
+    "K_STOP": {"buy": {level: k | None}, "sell": {level: k | None}},  # derived
+}
+```
+
+**Files:**
+- Modify: `core/config.py`, `core/validation.py`, `trading/parameters_manager.py`, `trading/positions_manager.py`, `trading/engine.py`, `trading/backtest.py`, `trading/optimizer/search.py`
+- Test: `tests/unit/trading/test_engine.py`, `test_backtest.py`, `test_positions_manager.py`, `test_parameters_manager.py`, `tests/unit/optimizer/test_search.py`, `tests/unit/core/test_validation.py`
+
+- [ ] **Step 1: Rewrite `_build_trading_params` and add dict helpers in `core/config.py`**
+
+Replace the `_build_trading_params` function (currently `core/config.py:61-74`) with:
+
+```python
+# Trading params
+def _build_trading_params() -> dict[str, dict[str, Any]]:
+    params = {}
+    for pair in PAIRS:
+        params[pair] = {
+            "K_ACT": os.getenv(f"{pair}_K_ACT"),
+            "MIN_MARGIN": os.getenv(f"{pair}_MIN_MARGIN"),
+            "K_STOP": {"buy": {}, "sell": {}},
+        }
+    return params
+```
+
+Then add these two helpers at the end of `core/config.py` (after `STOP_PERCENTILES = _build_percentiles()`):
+
+```python
+# Flat config view <-> live dicts. The "flat" dict uses the keys
+# target_pct, hodl_pct, k_act, min_margin, stop_pct_ll..stop_pct_hh and is the
+# representation shared by validation, the config store, and the API.
+def set_pair_config(pair: str, typed: dict[str, Any]) -> None:
+    TRADING_PARAMS[pair]["K_ACT"] = typed["k_act"]
+    TRADING_PARAMS[pair]["MIN_MARGIN"] = typed["min_margin"]
+    ASSET_ALLOCATION[pair]["TARGET_PCT"] = typed["target_pct"]
+    ASSET_ALLOCATION[pair]["HODL_PCT"] = typed["hodl_pct"]
+    for lvl in VOLATILITY_LEVELS:
+        STOP_PERCENTILES[pair][lvl] = typed[f"stop_pct_{lvl.lower()}"]
+
+
+def get_pair_config(pair: str) -> dict[str, Any]:
+    flat = {
+        "k_act": TRADING_PARAMS[pair]["K_ACT"],
+        "min_margin": TRADING_PARAMS[pair]["MIN_MARGIN"],
+        "target_pct": ASSET_ALLOCATION[pair]["TARGET_PCT"],
+        "hodl_pct": ASSET_ALLOCATION[pair]["HODL_PCT"],
+    }
+    for lvl in VOLATILITY_LEVELS:
+        flat[f"stop_pct_{lvl.lower()}"] = STOP_PERCENTILES[pair][lvl]
+    return flat
+```
+
+- [ ] **Step 2: Add `normalize_pair_config` + `target_sum_error` and rewrite `validate_pair_params` in `core/validation.py`**
+
+Replace the whole `validate_pair_params` function (currently `core/validation.py:93-159`) with:
+
+```python
+def normalize_pair_config(pair: str, raw: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Validate + normalize one pair's flat config.
+
+    ``raw`` keys: k_act, min_margin, target_pct, hodl_pct, stop_pct_ll..stop_pct_hh
+    (values may be strings, floats, or None). Returns (typed_flat, errors).
+    Rules:
+    - k_act: float >= 0, or None (falls through to K_STOP + MIN_MARGIN path).
+    - min_margin: float >= 0; required when k_act is None; normalized to 0.0 when
+      k_act is set.
+    - target_pct, hodl_pct: float in [0, 100] (default 0.0 when unset).
+    - stop_pct_<level>: float in [0, 1] (default STOP_PCT_DEFAULT when unset).
+    The cross-pair target sum is checked separately by target_sum_error.
+    """
+    errors: list[str] = []
+    out: dict[str, Any] = {}
+
+    k_act = _parse_float(raw.get("k_act"), f"{pair}_K_ACT", errors, min_val=0)
+    out["k_act"] = k_act
+
+    mm_raw = raw.get("min_margin")
+    if k_act is None:
+        min_margin = _parse_float(mm_raw, f"{pair}_MIN_MARGIN", errors, min_val=0)
+        if min_margin is None and mm_raw in (None, ""):
+            errors.append(f"{pair}_MIN_MARGIN is required when K_ACT is not set")
+        out["min_margin"] = min_margin
+    else:
+        parsed = _parse_float(mm_raw, f"{pair}_MIN_MARGIN", [], min_val=0)
+        out["min_margin"] = parsed if parsed is not None else 0.0
+
+    target = _parse_float(raw.get("target_pct"), f"{pair}_TARGET_PCT", errors, min_val=0, max_val=100)
+    out["target_pct"] = target if target is not None else 0.0
+
+    hodl = _parse_float(raw.get("hodl_pct"), f"{pair}_HODL_PCT", errors, min_val=0, max_val=100)
+    out["hodl_pct"] = hodl if hodl is not None else 0.0
+
+    for level in VOLATILITY_LEVELS:
+        key = f"stop_pct_{level.lower()}"
+        parsed = _parse_float(raw.get(key), f"{pair}_STOP_PCT_{level}", errors, min_val=0, max_val=1)
+        out[key] = parsed if parsed is not None else STOP_PCT_DEFAULT
+
+    return out, errors
+
+
+def target_sum_error(targets: dict[str, float]) -> str | None:
+    """Return an error string if the sum of target_pct across pairs exceeds 100."""
+    total = sum(targets.values())
+    if total > 100:
+        return f"Sum of TARGET_PCT across all pairs must not exceed 100 (got {total:g})"
+    return None
+
+
+def validate_pair_params(errors: list[str]) -> None:
+    """Validate and normalize per-pair trading parameters, writing typed values
+    back into the live dicts. Shares normalize_pair_config with the runtime
+    config store so startup and runtime apply identical rules."""
+    typed_targets: dict[str, float] = {}
+    for pair in PAIRS:
+        raw = {
+            "k_act": TRADING_PARAMS[pair]["K_ACT"],
+            "min_margin": TRADING_PARAMS[pair]["MIN_MARGIN"],
+            "target_pct": ASSET_ALLOCATION[pair]["TARGET_PCT"],
+            "hodl_pct": ASSET_ALLOCATION[pair]["HODL_PCT"],
+        }
+        for lvl in VOLATILITY_LEVELS:
+            raw[f"stop_pct_{lvl.lower()}"] = STOP_PERCENTILES[pair][lvl]
+
+        typed, errs = normalize_pair_config(pair, raw)
+        errors.extend(errs)
+        config.set_pair_config(pair, typed)
+        typed_targets[pair] = typed["target_pct"]
+
+    err = target_sum_error(typed_targets)
+    if err:
+        errors.append(err)
+```
+
+Add `import core.config as config` near the top of `core/validation.py` (after the existing imports), and keep the existing `from core.config import (...)` block — it already imports `STOP_PCT_DEFAULT`, `VOLATILITY_LEVELS`, `TRADING_PARAMS`, `ASSET_ALLOCATION`, `STOP_PERCENTILES`, `PAIRS`. The `set_pair_config` helper is called via the `config` module alias to keep the write path in one place.
+
+- [ ] **Step 3: Update `trading/parameters_manager.py` for the nested `K_STOP`**
+
+In `calculate_trading_parameters`, replace the two K_STOP writes (currently `trading/parameters_manager.py:66-67`):
+
+```python
+    TRADING_PARAMS[pair]["sell"]["K_STOP"] = sell_k_stops
+    TRADING_PARAMS[pair]["buy"]["K_STOP"] = buy_k_stops
+```
+
+with:
+
+```python
+    TRADING_PARAMS[pair]["K_STOP"] = {"sell": sell_k_stops, "buy": buy_k_stops}
+```
+
+In `build_calibration` (currently `trading/parameters_manager.py:102-103`), replace:
+
+```python
+        k_stop_buy=dict(TRADING_PARAMS[pair]["buy"].get("K_STOP") or {}),
+        k_stop_sell=dict(TRADING_PARAMS[pair]["sell"].get("K_STOP") or {}),
+```
+
+with:
+
+```python
+        k_stop_buy=dict(TRADING_PARAMS[pair]["K_STOP"].get("buy") or {}),
+        k_stop_sell=dict(TRADING_PARAMS[pair]["K_STOP"].get("sell") or {}),
+```
+
+In `get_k_stop`, replace the three `TRADING_PARAMS[pair][side]["K_STOP"]` / `TRADING_PARAMS[pair][op_side]["K_STOP"]` accesses (currently lines 123, 129, 138) so they index `["K_STOP"]` first:
+
+```python
+    k_stop = TRADING_PARAMS[pair]["K_STOP"][side].get(vol)
+```
+```python
+    k_stop = TRADING_PARAMS[pair]["K_STOP"][op_side].get(vol)
+```
+```python
+                k_stop = TRADING_PARAMS[pair]["K_STOP"][side].get(LEVELS[neighbor])
+```
+
+- [ ] **Step 4: Update `trading/positions_manager.py` to read pair-level params**
+
+In `calculate_activation_distance` (currently `trading/positions_manager.py:47-57`), replace:
+
+```python
+    k_act = TRADING_PARAMS[pair][side]["K_ACT"]
+```
+with
+```python
+    k_act = TRADING_PARAMS[pair]["K_ACT"]
+```
+
+and replace:
+
+```python
+    min_margin = float(TRADING_PARAMS[pair][side]["MIN_MARGIN"])
+```
+with
+```python
+    min_margin = float(TRADING_PARAMS[pair]["MIN_MARGIN"])
+```
+
+- [ ] **Step 5: Collapse `EngineConfig` in `trading/engine.py`**
+
+Remove the `SidePolicy` dataclass (currently `trading/engine.py:28-32`) and replace the `EngineConfig` dataclass (currently lines 34-41) with:
+
+```python
+@dataclass(frozen=True)
+class EngineConfig:
+    pair: str
+    calibration: PairCalibration
+    k_act: float | None
+    min_margin: float
+    atr_desv_limit: float
+```
+
+Replace `activation_distance` (currently lines 106-112) with:
+
+```python
+def activation_distance(cfg: EngineConfig, side: str, reference_price: float, atr_val: float) -> float:
+    k_act = cfg.k_act
+    if k_act is not None:
+        return float(k_act) * atr_val
+    k_stop = lookup_k_stop(cfg, side, atr_val) or 0.0
+    return float(k_stop) * atr_val + (cfg.min_margin * reference_price)
+```
+
+- [ ] **Step 6: Update `trading/backtest.py` EngineConfig construction**
+
+Change the import (currently `trading/backtest.py:15`) to drop `SidePolicy`:
+
+```python
+from trading.engine import EngineConfig, Operation, PairCalibration, simulate_operations
+```
+
+Replace the `side_buy` / `side_sell` / `cfg` block (currently lines 131-139) with:
+
+```python
+    cfg = EngineConfig(
+        req.pair,
+        calibration,
+        k_act=_coerce_float(TRADING_PARAMS[req.pair].get("K_ACT")),
+        min_margin=float(TRADING_PARAMS[req.pair].get("MIN_MARGIN") or 0.0),
+        atr_desv_limit=ATR_DESV_LIMIT,
+    )
+```
+
+- [ ] **Step 7: Update `trading/optimizer/search.py` EngineConfig + env read**
+
+Change the import (currently `trading/optimizer/search.py:41`) to drop `SidePolicy`:
+
+```python
+from trading.engine import EngineConfig, PairCalibration, simulate_operations
+```
+
+Replace the last two lines of `_build_engine_config` (currently lines 255-256):
+
+```python
+    side = SidePolicy(k_act=cand.k_act, min_margin=cand.min_margin or 0.0)
+    return EngineConfig(pair=pair, calibration=calibration, buy=side, sell=side, atr_desv_limit=atr_desv_limit)
+```
+with:
+```python
+    return EngineConfig(
+        pair=pair,
+        calibration=calibration,
+        k_act=cand.k_act,
+        min_margin=cand.min_margin or 0.0,
+        atr_desv_limit=atr_desv_limit,
+    )
+```
+
+In `_candidate_from_env` (currently lines 198-221), replace the two `TRADING_PARAMS[pair]["buy"].get(...)` reads (lines 204 and 212) with pair-level reads:
+
+```python
+        raw_k_act = TRADING_PARAMS[pair].get("K_ACT")
+```
+```python
+        raw_mm = TRADING_PARAMS[pair].get("MIN_MARGIN", 0) or 0
+```
+
+- [ ] **Step 8: Update collapse-affected tests**
+
+Apply these mechanical transformations across the listed test files (search each file for the old form and replace):
+
+- `tests/unit/trading/test_engine.py`, `tests/unit/trading/test_backtest.py`, `tests/unit/optimizer/test_search.py`:
+  - Remove any `SidePolicy` import and construction.
+  - Replace `EngineConfig(..., buy=<X>, sell=<Y>, atr_desv_limit=Z)` with `EngineConfig(..., k_act=<X.k_act>, min_margin=<X.min_margin>, atr_desv_limit=Z)`. Where the test built a `SidePolicy(k_act=a, min_margin=m)` for both sides, pass `k_act=a, min_margin=m` directly.
+- `tests/unit/trading/test_positions_manager.py`, `tests/unit/trading/test_parameters_manager.py`, `tests/unit/core/test_validation.py`:
+  - Replace any `TRADING_PARAMS[pair]["buy"]["K_ACT"]` / `["sell"]["K_ACT"]` / `["buy"]["MIN_MARGIN"]` / `["sell"]["MIN_MARGIN"]` fixtures with the pair-level keys `TRADING_PARAMS[pair]["K_ACT"]` / `["MIN_MARGIN"]`.
+  - Replace any `TRADING_PARAMS[pair]["buy"]["K_STOP"]` / `["sell"]["K_STOP"]` with `TRADING_PARAMS[pair]["K_STOP"]["buy"]` / `["sell"]`.
+  - Any fixture dict literal of the old shape `{"buy": {"K_ACT": ...}, "sell": {...}}` becomes `{"K_ACT": ..., "MIN_MARGIN": ..., "K_STOP": {"buy": {...}, "sell": {...}}}`.
+  - In `test_validation.py`, update assertions that referenced per-side k_act/min_margin to the pair-level keys, and keep the `TARGET_PCT` sum test (it now flows through `target_sum_error`).
+
+- [ ] **Step 9: Run the affected suites to verify green**
+
+Run: `PYTHONPATH=. pytest tests/unit/trading/ tests/unit/optimizer/ tests/unit/core/test_validation.py -v`
+Expected: PASS (all collapse-affected tests green).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add core/config.py core/validation.py trading/parameters_manager.py trading/positions_manager.py trading/engine.py trading/backtest.py trading/optimizer/search.py tests/unit/trading/ tests/unit/optimizer/ tests/unit/core/test_validation.py
+git commit -m "refactor: collapse k_act/min_margin to a single per-pair value"
+```
+
+---
+
+## Task 2: `pair_config` table (model + migration + DAL)
+
+**Files:**
+- Modify: `core/database.py`
+- Create: `scripts/migrations/versions/20260616_01_pair_config.py`
+- Test: `tests/unit/core/test_database.py`
+
+- [ ] **Step 1: Add the `PairConfig` ORM model in `core/database.py`**
+
+Add after the `BotControl` model (after `core/database.py:263`):
+
+```python
+class PairConfig(Base):
+    """Per-pair dynamic trading configuration (DB-authoritative, seeded from env)."""
+
+    __tablename__ = "pair_config"
+
+    pair = Column(Text, primary_key=True, nullable=False)
+    target_pct = Column(Numeric(6, 3), nullable=False, default=0)
+    hodl_pct = Column(Numeric(6, 3), nullable=False, default=0)
+    k_act = Column(Numeric(10, 4), nullable=True)
+    min_margin = Column(Numeric(12, 8), nullable=False, default=0)
+    stop_pct_ll = Column(Numeric(4, 3), nullable=False, default=0.90)
+    stop_pct_lv = Column(Numeric(4, 3), nullable=False, default=0.90)
+    stop_pct_mv = Column(Numeric(4, 3), nullable=False, default=0.90)
+    stop_pct_hv = Column(Numeric(4, 3), nullable=False, default=0.90)
+    stop_pct_hh = Column(Numeric(4, 3), nullable=False, default=0.90)
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+    updated_by = Column(Text, nullable=True)
+
+    __table_args__ = (
+        CheckConstraint("target_pct >= 0 AND target_pct <= 100", name="ck_pair_config_target_pct_range"),
+        CheckConstraint("hodl_pct >= 0 AND hodl_pct <= 100", name="ck_pair_config_hodl_pct_range"),
+        CheckConstraint("k_act IS NULL OR k_act >= 0", name="ck_pair_config_k_act_nonneg"),
+        CheckConstraint("min_margin >= 0", name="ck_pair_config_min_margin_nonneg"),
+        CheckConstraint("stop_pct_ll >= 0 AND stop_pct_ll <= 1", name="ck_pair_config_stop_ll_range"),
+        CheckConstraint("stop_pct_lv >= 0 AND stop_pct_lv <= 1", name="ck_pair_config_stop_lv_range"),
+        CheckConstraint("stop_pct_mv >= 0 AND stop_pct_mv <= 1", name="ck_pair_config_stop_mv_range"),
+        CheckConstraint("stop_pct_hv >= 0 AND stop_pct_hv <= 1", name="ck_pair_config_stop_hv_range"),
+        CheckConstraint("stop_pct_hh >= 0 AND stop_pct_hh <= 1", name="ck_pair_config_stop_hh_range"),
+    )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "pair": self.pair,
+            "target_pct": float(self.target_pct),
+            "hodl_pct": float(self.hodl_pct),
+            "k_act": float(self.k_act) if self.k_act is not None else None,
+            "min_margin": float(self.min_margin),
+            "stop_pct_ll": float(self.stop_pct_ll),
+            "stop_pct_lv": float(self.stop_pct_lv),
+            "stop_pct_mv": float(self.stop_pct_mv),
+            "stop_pct_hv": float(self.stop_pct_hv),
+            "stop_pct_hh": float(self.stop_pct_hh),
+            "updated_at": self.updated_at,
+            "updated_by": self.updated_by,
+        }
+```
+
+- [ ] **Step 2: Add DAL functions in `core/database.py`**
+
+Add after the Bot Control Operations section (after `set_bot_paused`, around `core/database.py:694`):
+
+```python
+# ============================================================================
+# Pair Config Operations
+# ============================================================================
+
+
+def load_all_pair_config() -> dict[str, dict[str, Any]]:
+    """Return {pair: pair_config_dict} for all stored pairs."""
+    try:
+        with get_session() as session:
+            return {row.pair: row.to_dict() for row in session.query(PairConfig).all()}
+    except Exception as e:
+        logger.error(f"Error loading pair_config: {e}")
+        return {}
+
+
+def upsert_pair_config(pair: str, values: dict[str, Any], updated_by: str | None = None) -> None:
+    """Insert or update one pair's config row. ``values`` is a flat typed dict
+    with keys target_pct, hodl_pct, k_act, min_margin, stop_pct_ll..stop_pct_hh."""
+    with get_session() as session:
+        session.merge(PairConfig(pair=pair, updated_by=updated_by, **values))
+    logger.debug(f"Saved pair_config for {pair}")
+```
+
+- [ ] **Step 3: Write the Alembic migration**
+
+Create `scripts/migrations/versions/20260616_01_pair_config.py`:
+
+```python
+"""Phase 1 (V3): add pair_config table for dynamic per-pair configuration.
+
+Revision ID: 20260616_01
+Revises: 20260608_01
+Create Date: 2026-06-16 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260616_01"
+down_revision = "20260608_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pair_config",
+        sa.Column("pair", sa.Text(), primary_key=True, nullable=False),
+        sa.Column("target_pct", sa.Numeric(6, 3), nullable=False, server_default="0"),
+        sa.Column("hodl_pct", sa.Numeric(6, 3), nullable=False, server_default="0"),
+        sa.Column("k_act", sa.Numeric(10, 4), nullable=True),
+        sa.Column("min_margin", sa.Numeric(12, 8), nullable=False, server_default="0"),
+        sa.Column("stop_pct_ll", sa.Numeric(4, 3), nullable=False, server_default="0.90"),
+        sa.Column("stop_pct_lv", sa.Numeric(4, 3), nullable=False, server_default="0.90"),
+        sa.Column("stop_pct_mv", sa.Numeric(4, 3), nullable=False, server_default="0.90"),
+        sa.Column("stop_pct_hv", sa.Numeric(4, 3), nullable=False, server_default="0.90"),
+        sa.Column("stop_pct_hh", sa.Numeric(4, 3), nullable=False, server_default="0.90"),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_by", sa.Text(), nullable=True),
+        sa.CheckConstraint("target_pct >= 0 AND target_pct <= 100", name="ck_pair_config_target_pct_range"),
+        sa.CheckConstraint("hodl_pct >= 0 AND hodl_pct <= 100", name="ck_pair_config_hodl_pct_range"),
+        sa.CheckConstraint("k_act IS NULL OR k_act >= 0", name="ck_pair_config_k_act_nonneg"),
+        sa.CheckConstraint("min_margin >= 0", name="ck_pair_config_min_margin_nonneg"),
+        sa.CheckConstraint("stop_pct_ll >= 0 AND stop_pct_ll <= 1", name="ck_pair_config_stop_ll_range"),
+        sa.CheckConstraint("stop_pct_lv >= 0 AND stop_pct_lv <= 1", name="ck_pair_config_stop_lv_range"),
+        sa.CheckConstraint("stop_pct_mv >= 0 AND stop_pct_mv <= 1", name="ck_pair_config_stop_mv_range"),
+        sa.CheckConstraint("stop_pct_hv >= 0 AND stop_pct_hv <= 1", name="ck_pair_config_stop_hv_range"),
+        sa.CheckConstraint("stop_pct_hh >= 0 AND stop_pct_hh <= 1", name="ck_pair_config_stop_hh_range"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("pair_config")
+```
+
+- [ ] **Step 4: Write the failing test for the DAL round-trip**
+
+Add to `tests/unit/core/test_database.py`:
+
+```python
+def test_pair_config_to_dict_round_trips_types():
+    from decimal import Decimal
+    from core.database import PairConfig
+
+    row = PairConfig(
+        pair="XBTEUR",
+        target_pct=Decimal("30.000"),
+        hodl_pct=Decimal("10.000"),
+        k_act=Decimal("2.0000"),
+        min_margin=Decimal("0.00100000"),
+        stop_pct_ll=Decimal("0.900"),
+        stop_pct_lv=Decimal("0.900"),
+        stop_pct_mv=Decimal("0.900"),
+        stop_pct_hv=Decimal("0.900"),
+        stop_pct_hh=Decimal("0.950"),
+    )
+    d = row.to_dict()
+    assert d["pair"] == "XBTEUR"
+    assert d["target_pct"] == 30.0
+    assert d["k_act"] == 2.0
+    assert d["stop_pct_hh"] == 0.95
+    assert isinstance(d["min_margin"], float)
+```
+
+- [ ] **Step 5: Run the test**
+
+Run: `PYTHONPATH=. pytest tests/unit/core/test_database.py::test_pair_config_to_dict_round_trips_types -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add core/database.py scripts/migrations/versions/20260616_01_pair_config.py tests/unit/core/test_database.py
+git commit -m "feat(db): add pair_config table, model and DAL"
+```
+
+---
+
+## Task 3: Runtime config dirty flag + scheduler recalc
+
+**Files:**
+- Modify: `core/runtime.py`, `core/scheduler.py`
+- Test: `tests/unit/core/test_runtime.py`, `tests/unit/core/test_scheduler.py`
+
+- [ ] **Step 1: Write failing tests for the dirty flag in `tests/unit/core/test_runtime.py`**
+
+```python
+def test_config_dirty_flag_set_and_pop():
+    import core.runtime as runtime
+
+    assert runtime.pop_config_dirty("XBTEUR") is False
+    runtime.mark_config_dirty("XBTEUR")
+    assert runtime.pop_config_dirty("XBTEUR") is True
+    # second pop returns False (cleared)
+    assert runtime.pop_config_dirty("XBTEUR") is False
+
+
+def test_config_dirty_flag_is_per_pair():
+    import core.runtime as runtime
+
+    runtime.mark_config_dirty("ETHEUR")
+    assert runtime.pop_config_dirty("XBTEUR") is False
+    assert runtime.pop_config_dirty("ETHEUR") is True
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `PYTHONPATH=. pytest tests/unit/core/test_runtime.py::test_config_dirty_flag_set_and_pop -v`
+Expected: FAIL with `AttributeError: module 'core.runtime' has no attribute 'pop_config_dirty'`.
+
+- [ ] **Step 3: Implement the dirty flag in `core/runtime.py`**
+
+Add `"config_dirty": set()` to the `_shared_data` dict (after the `pair_calibration` entry), then add at the end of the module:
+
+```python
+def mark_config_dirty(pair: str) -> None:
+    with _lock:
+        _shared_data["config_dirty"].add(pair)
+
+
+def pop_config_dirty(pair: str) -> bool:
+    """Return True (and clear) if pair's config changed since the last check."""
+    with _lock:
+        if pair in _shared_data["config_dirty"]:
+            _shared_data["config_dirty"].discard(pair)
+            return True
+        return False
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `PYTHONPATH=. pytest tests/unit/core/test_runtime.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Update the scheduler recalc condition in `core/scheduler.py`**
+
+Replace (currently `core/scheduler.py:93-94`):
+
+```python
+            if _session_count % PARAM_SESSIONS == 0:
+                calculate_trading_parameters(pair)
+```
+with:
+```python
+            if _session_count % PARAM_SESSIONS == 0 or runtime.pop_config_dirty(pair):
+                calculate_trading_parameters(pair)
+```
+
+- [ ] **Step 6: Write a failing test for the scheduler dirty-flag recalc in `tests/unit/core/test_scheduler.py`**
+
+Match the file's existing monkeypatch style for `trading_session`. Add:
+
+```python
+def test_session_recalcs_params_when_config_dirty(monkeypatch):
+    import core.scheduler as scheduler
+    import core.runtime as runtime
+
+    calls = []
+    monkeypatch.setattr(scheduler, "calculate_trading_parameters", lambda pair, *a, **k: calls.append(pair))
+    monkeypatch.setattr(scheduler.db, "create_session", lambda *_a, **_k: 1)
+    monkeypatch.setattr(scheduler.db, "get_bot_paused", lambda: False)
+    monkeypatch.setattr(scheduler.db, "finalize_session", lambda *a, **k: None)
+    monkeypatch.setattr(scheduler.db, "load_trailing_state", lambda pair: None)
+    monkeypatch.setattr(scheduler, "PAIRS", {"XBTEUR": {}})
+    monkeypatch.setattr(scheduler, "get_balance", lambda: {"ZEUR": 100.0})
+    monkeypatch.setattr(scheduler, "get_last_prices", lambda pairs: {"XBTEUR": 80000.0})
+    monkeypatch.setattr(scheduler, "get_current_atr", lambda pair: 500.0)
+    monkeypatch.setattr(scheduler, "get_volatility_level", lambda pair, atr: "MV")
+    monkeypatch.setattr(scheduler, "TRADING_ENABLED", False)
+    monkeypatch.setattr(scheduler, "PARAM_SESSIONS", 720)
+    # Force the counter off a multiple of PARAM_SESSIONS so only the dirty flag can trigger.
+    monkeypatch.setattr(scheduler, "_session_count", 1)
+
+    runtime.mark_config_dirty("XBTEUR")
+    scheduler.trading_session()
+
+    assert calls == ["XBTEUR"]
+```
+
+If the existing test module already monkeypatches a helper set for `trading_session`, reuse it instead of duplicating; the key assertion is that `calculate_trading_parameters` is called for a dirty pair when `_session_count` is not a multiple of `PARAM_SESSIONS`.
+
+- [ ] **Step 7: Run scheduler + runtime tests**
+
+Run: `PYTHONPATH=. pytest tests/unit/core/test_runtime.py tests/unit/core/test_scheduler.py -v`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add core/runtime.py core/scheduler.py tests/unit/core/test_runtime.py tests/unit/core/test_scheduler.py
+git commit -m "feat(runtime): config dirty flag triggers K_STOP recalc next session"
+```
+
+---
+
+## Task 4: `core/config_store.py`
+
+**Files:**
+- Create: `core/config_store.py`
+- Test: `tests/unit/core/test_config_store.py`
+
+- [ ] **Step 1: Write `core/config_store.py`**
+
+```python
+"""Single owner of dynamic per-pair configuration.
+
+The live module-level dicts in ``core.config`` (TRADING_PARAMS, ASSET_ALLOCATION,
+STOP_PERCENTILES) remain the read path for the trading loop. This module keeps
+them current: it seeds them from the DB (or seeds the DB from them) at startup,
+and applies validated runtime patches. A module lock makes each multi-field patch
+atomic against the scheduler's reads.
+"""
+
+import threading
+from typing import Any
+
+import core.config as config
+import core.database as db
+import core.runtime as runtime
+from core.config import PAIRS, VOLATILITY_LEVELS
+from core.validation import normalize_pair_config, target_sum_error
+
+_lock = threading.Lock()
+
+# The flat config keys persisted in pair_config and exchanged with the API.
+FLAT_KEYS = (
+    "target_pct",
+    "hodl_pct",
+    "k_act",
+    "min_margin",
+    *[f"stop_pct_{lvl.lower()}" for lvl in VOLATILITY_LEVELS],
+)
+
+
+class UnknownPairError(Exception):
+    """Raised when a config operation targets a pair not in PAIRS."""
+
+
+class ConfigValidationError(Exception):
+    """Raised when a patch fails validation. Carries the list of error strings."""
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        super().__init__("; ".join(errors))
+
+
+def _flat_from_row(row: dict[str, Any]) -> dict[str, Any]:
+    return {k: row[k] for k in FLAT_KEYS}
+
+
+def get_pair(pair: str) -> dict[str, Any]:
+    """Current typed flat config for one pair, read from the live dicts."""
+    return config.get_pair_config(pair)
+
+
+def get_all() -> dict[str, dict[str, Any]]:
+    return {pair: config.get_pair_config(pair) for pair in PAIRS}
+
+
+def load_or_seed() -> None:
+    """Startup sync. For each pair: load the DB row into the live dicts if present,
+    otherwise seed a row from the (already env-validated) live dict values."""
+    rows = db.load_all_pair_config()
+    for pair in PAIRS:
+        if pair in rows:
+            config.set_pair_config(pair, _flat_from_row(rows[pair]))
+        else:
+            db.upsert_pair_config(pair, config.get_pair_config(pair), updated_by="seed")
+
+
+def apply_patch(pair: str, fields: dict[str, Any], updated_by: str | None = None) -> dict[str, Any]:
+    """Validate, persist, and apply a partial config change for one pair.
+
+    Returns the new typed flat config. Raises UnknownPairError for an unknown
+    pair, ConfigValidationError on validation failure (nothing persisted or
+    applied). Persist-then-apply: if the DB write fails the live dicts are
+    untouched (the exception propagates)."""
+    with _lock:
+        if pair not in PAIRS:
+            raise UnknownPairError(pair)
+
+        current = config.get_pair_config(pair)
+        merged = {**current, **fields}
+        typed, errors = normalize_pair_config(pair, merged)
+
+        targets = {p: config.get_pair_config(p)["target_pct"] for p in PAIRS if p != pair}
+        targets[pair] = typed["target_pct"]
+        sum_err = target_sum_error(targets)
+        if sum_err:
+            errors.append(sum_err)
+
+        if errors:
+            raise ConfigValidationError(errors)
+
+        stop_changed = any(
+            typed[f"stop_pct_{lvl.lower()}"] != current[f"stop_pct_{lvl.lower()}"] for lvl in VOLATILITY_LEVELS
+        )
+
+        db.upsert_pair_config(pair, typed, updated_by=updated_by)
+        config.set_pair_config(pair, typed)
+        if stop_changed:
+            runtime.mark_config_dirty(pair)
+
+        return typed
+```
+
+- [ ] **Step 2: Write tests in `tests/unit/core/test_config_store.py`**
+
+```python
+import pytest
+
+import core.config as config
+import core.config_store as config_store
+import core.runtime as runtime
+
+
+def _seed_dicts(monkeypatch, pairs):
+    monkeypatch.setattr(config, "PAIRS", pairs)
+    monkeypatch.setattr(config_store, "PAIRS", pairs)
+    monkeypatch.setattr(config, "TRADING_PARAMS", {p: {"K_ACT": 2.0, "MIN_MARGIN": 0.0, "K_STOP": {"buy": {}, "sell": {}}} for p in pairs})
+    monkeypatch.setattr(config, "ASSET_ALLOCATION", {p: {"TARGET_PCT": 30.0, "HODL_PCT": 10.0} for p in pairs})
+    monkeypatch.setattr(config, "STOP_PERCENTILES", {p: {lvl: 0.90 for lvl in config.VOLATILITY_LEVELS} for p in pairs})
+
+
+def test_load_or_seed_inserts_when_row_absent(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    monkeypatch.setattr(config_store.db, "load_all_pair_config", lambda: {})
+    saved = {}
+    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda pair, values, updated_by=None: saved.update({pair: values}))
+
+    config_store.load_or_seed()
+
+    assert saved["XBTEUR"]["k_act"] == 2.0
+    assert saved["XBTEUR"]["target_pct"] == 30.0
+
+
+def test_load_or_seed_loads_when_row_present(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    row = {
+        "pair": "XBTEUR", "target_pct": 40.0, "hodl_pct": 5.0, "k_act": None,
+        "min_margin": 0.002, "stop_pct_ll": 0.8, "stop_pct_lv": 0.8, "stop_pct_mv": 0.8,
+        "stop_pct_hv": 0.8, "stop_pct_hh": 0.9, "updated_at": None, "updated_by": None,
+    }
+    monkeypatch.setattr(config_store.db, "load_all_pair_config", lambda: {"XBTEUR": row})
+    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda *a, **k: pytest.fail("should not seed when row present"))
+
+    config_store.load_or_seed()
+
+    assert config.get_pair_config("XBTEUR")["target_pct"] == 40.0
+    assert config.get_pair_config("XBTEUR")["k_act"] is None
+    assert config.get_pair_config("XBTEUR")["min_margin"] == 0.002
+
+
+def test_apply_patch_unknown_pair_raises(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    with pytest.raises(config_store.UnknownPairError):
+        config_store.apply_patch("DOGEUR", {"target_pct": 1.0})
+
+
+def test_apply_patch_updates_dict_and_persists(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    saved = {}
+    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda pair, values, updated_by=None: saved.update({pair: values}))
+
+    result = config_store.apply_patch("XBTEUR", {"target_pct": 25.0}, updated_by="api")
+
+    assert result["target_pct"] == 25.0
+    assert config.get_pair_config("XBTEUR")["target_pct"] == 25.0
+    assert saved["XBTEUR"]["target_pct"] == 25.0
+
+
+def test_apply_patch_invalid_leaves_dict_and_db_untouched(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda *a, **k: pytest.fail("must not persist on invalid"))
+
+    with pytest.raises(config_store.ConfigValidationError):
+        config_store.apply_patch("XBTEUR", {"target_pct": 150.0})
+
+    assert config.get_pair_config("XBTEUR")["target_pct"] == 30.0  # unchanged
+
+
+def test_apply_patch_target_sum_over_100_rejected(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR", "ETHEUR"])  # each currently 30
+    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda *a, **k: pytest.fail("must not persist"))
+
+    with pytest.raises(config_store.ConfigValidationError) as exc:
+        config_store.apply_patch("XBTEUR", {"target_pct": 95.0})  # 95 + 30 > 100
+    assert any("TARGET_PCT" in e for e in exc.value.errors)
+
+
+def test_apply_patch_stop_pct_change_sets_dirty_flag(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda *a, **k: None)
+    marked = []
+    monkeypatch.setattr(config_store.runtime, "mark_config_dirty", lambda pair: marked.append(pair))
+
+    config_store.apply_patch("XBTEUR", {"stop_pct_hh": 0.95})
+    assert marked == ["XBTEUR"]
+
+
+def test_apply_patch_non_stop_change_does_not_set_dirty_flag(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda *a, **k: None)
+    marked = []
+    monkeypatch.setattr(config_store.runtime, "mark_config_dirty", lambda pair: marked.append(pair))
+
+    config_store.apply_patch("XBTEUR", {"target_pct": 20.0})
+    assert marked == []
+
+
+def test_apply_patch_k_act_null_requires_min_margin(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    # current min_margin is 0.0 and k_act is 2.0; setting k_act null with no margin -> still 0.0,
+    # which is a valid float, so this checks the null path accepts an explicit margin.
+    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda *a, **k: None)
+    result = config_store.apply_patch("XBTEUR", {"k_act": None, "min_margin": 0.001})
+    assert result["k_act"] is None
+    assert result["min_margin"] == 0.001
+```
+
+- [ ] **Step 3: Run the tests**
+
+Run: `PYTHONPATH=. pytest tests/unit/core/test_config_store.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add core/config_store.py tests/unit/core/test_config_store.py
+git commit -m "feat(config): add config_store for load/seed and atomic patches"
+```
+
+---
+
+## Task 5: HTTP API (schemas + route + wiring)
+
+**Files:**
+- Modify: `api/schemas.py`, `api/app.py`
+- Create: `api/routes/config.py`
+- Test: `tests/unit/api/test_config_route.py`
+
+- [ ] **Step 1: Add Pydantic models to `api/schemas.py`**
+
+Append:
+
+```python
+class PairConfig(BaseModel):
+    pair: str
+    target_pct: float
+    hodl_pct: float
+    k_act: float | None = None
+    min_margin: float
+    stop_pct_ll: float
+    stop_pct_lv: float
+    stop_pct_mv: float
+    stop_pct_hv: float
+    stop_pct_hh: float
+
+
+class PairConfigPatch(BaseModel):
+    """Partial update. Unset fields are ignored; an explicit null k_act switches
+    the pair to the K_STOP + MIN_MARGIN activation path."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    target_pct: float | None = Field(default=None, ge=0, le=100)
+    hodl_pct: float | None = Field(default=None, ge=0, le=100)
+    k_act: float | None = Field(default=None, ge=0)
+    min_margin: float | None = Field(default=None, ge=0)
+    stop_pct_ll: float | None = Field(default=None, ge=0, le=1)
+    stop_pct_lv: float | None = Field(default=None, ge=0, le=1)
+    stop_pct_mv: float | None = Field(default=None, ge=0, le=1)
+    stop_pct_hv: float | None = Field(default=None, ge=0, le=1)
+    stop_pct_hh: float | None = Field(default=None, ge=0, le=1)
+```
+
+Update the import at the top of `api/schemas.py` (currently `from pydantic import BaseModel, Field, model_validator`) to include `ConfigDict`:
+
+```python
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+```
+
+- [ ] **Step 2: Create `api/routes/config.py`**
+
+```python
+from fastapi import APIRouter, HTTPException
+
+import core.config_store as config_store
+from api.schemas import PairConfig, PairConfigPatch
+from core.config import PAIRS
+
+router = APIRouter(tags=["config"])
+
+
+def _to_model(pair: str, flat: dict) -> PairConfig:
+    return PairConfig(pair=pair, **flat)
+
+
+@router.get("/config", response_model=list[PairConfig])
+def get_config() -> list[PairConfig]:
+    return [_to_model(pair, flat) for pair, flat in config_store.get_all().items()]
+
+
+@router.get("/config/{pair}", response_model=PairConfig)
+def get_config_pair(pair: str) -> PairConfig:
+    if pair not in PAIRS:
+        raise HTTPException(status_code=404, detail=f"Unknown pair: {pair}")
+    return _to_model(pair, config_store.get_pair(pair))
+
+
+@router.patch("/config/{pair}", response_model=PairConfig)
+def patch_config_pair(pair: str, patch: PairConfigPatch) -> PairConfig:
+    if pair not in PAIRS:
+        raise HTTPException(status_code=404, detail=f"Unknown pair: {pair}")
+    fields = patch.model_dump(exclude_unset=True)
+    if not fields:
+        raise HTTPException(status_code=422, detail="No fields to update")
+    try:
+        typed = config_store.apply_patch(pair, fields, updated_by="api")
+    except config_store.ConfigValidationError as e:
+        raise HTTPException(status_code=422, detail="; ".join(e.errors))
+    return _to_model(pair, typed)
+```
+
+- [ ] **Step 3: Wire the router and startup seed in `api/app.py`**
+
+Update the routes import (currently `api/app.py:15`):
+
+```python
+from api.routes import balance, config, control, market, positions, status
+```
+
+In `lifespan`, after `if not db.check_database_connection(): ...` and before building the scheduler, add:
+
+```python
+    config_store.load_or_seed()
+```
+
+Add the import near the top of `api/app.py` (with the other `core` imports):
+
+```python
+import core.config_store as config_store
+```
+
+Add `config` to the router registration tuple (currently `api/app.py:87`):
+
+```python
+for _r in (balance, config, control, market, positions, status, backtest_route, optimizer_route):
+```
+
+- [ ] **Step 4: Write tests in `tests/unit/api/test_config_route.py`**
+
+```python
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import core.config_store as config_store
+from api.routes import config as config_route
+
+_PAIRS = {"XBTEUR": {}, "ETHEUR": {}}
+_FLAT = {
+    "target_pct": 30.0, "hodl_pct": 10.0, "k_act": 2.0, "min_margin": 0.0,
+    "stop_pct_ll": 0.9, "stop_pct_lv": 0.9, "stop_pct_mv": 0.9,
+    "stop_pct_hv": 0.9, "stop_pct_hh": 0.9,
+}
+
+
+def _client(monkeypatch):
+    monkeypatch.setattr(config_route, "PAIRS", _PAIRS)
+    app = FastAPI()
+    app.include_router(config_route.router)
+    return TestClient(app)
+
+
+def test_get_config_all(monkeypatch):
+    monkeypatch.setattr(config_store, "get_all", lambda: {p: dict(_FLAT) for p in _PAIRS})
+    body = _client(monkeypatch).get("/config").json()
+    pairs = {item["pair"] for item in body}
+    assert pairs == {"XBTEUR", "ETHEUR"}
+
+
+def test_get_config_pair(monkeypatch):
+    monkeypatch.setattr(config_store, "get_pair", lambda pair: dict(_FLAT))
+    body = _client(monkeypatch).get("/config/XBTEUR").json()
+    assert body["pair"] == "XBTEUR"
+    assert body["k_act"] == 2.0
+
+
+def test_get_config_unknown_pair_404(monkeypatch):
+    assert _client(monkeypatch).get("/config/DOGEUR").status_code == 404
+
+
+def test_patch_config_success(monkeypatch):
+    captured = {}
+
+    def _apply(pair, fields, updated_by=None):
+        captured["pair"] = pair
+        captured["fields"] = fields
+        return {**_FLAT, **fields}
+
+    monkeypatch.setattr(config_store, "apply_patch", _apply)
+    resp = _client(monkeypatch).patch("/config/XBTEUR", json={"target_pct": 25.0})
+    assert resp.status_code == 200
+    assert resp.json()["target_pct"] == 25.0
+    assert captured["fields"] == {"target_pct": 25.0}
+
+
+def test_patch_config_explicit_null_k_act_is_forwarded(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(config_store, "apply_patch", lambda pair, fields, updated_by=None: captured.update(fields) or {**_FLAT, "k_act": None, "min_margin": 0.001})
+    resp = _client(monkeypatch).patch("/config/XBTEUR", json={"k_act": None, "min_margin": 0.001})
+    assert resp.status_code == 200
+    assert captured["k_act"] is None
+
+
+def test_patch_config_validation_error_422(monkeypatch):
+    def _apply(pair, fields, updated_by=None):
+        raise config_store.ConfigValidationError(["XBTEUR_TARGET_PCT must be <= 100 (got 150)"])
+
+    monkeypatch.setattr(config_store, "apply_patch", _apply)
+    resp = _client(monkeypatch).patch("/config/XBTEUR", json={"target_pct": 99.0})
+    assert resp.status_code == 422
+    assert "TARGET_PCT" in resp.json()["detail"]
+
+
+def test_patch_config_empty_body_422(monkeypatch):
+    resp = _client(monkeypatch).patch("/config/XBTEUR", json={})
+    assert resp.status_code == 422
+
+
+def test_patch_config_unknown_pair_404(monkeypatch):
+    assert _client(monkeypatch).patch("/config/DOGEUR", json={"target_pct": 1.0}).status_code == 404
+```
+
+- [ ] **Step 5: Run the route tests**
+
+Run: `PYTHONPATH=. pytest tests/unit/api/test_config_route.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Add the auth-coverage assertion in `tests/unit/api/test_api.py`**
+
+In `test_full_app_rejects_request_without_token`, add `/config` to the GET loop so the new router is covered by the auth check. Change the tuple (currently `tests/unit/api/test_api.py:98`):
+
+```python
+    for path in ("/balance", "/status", "/market", "/positions", "/config"):
+```
+
+- [ ] **Step 7: Run the API suite**
+
+Run: `PYTHONPATH=. pytest tests/unit/api/ -v`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add api/schemas.py api/routes/config.py api/app.py tests/unit/api/test_config_route.py tests/unit/api/test_api.py
+git commit -m "feat(api): config GET/PATCH endpoints + startup seed"
+```
+
+---
+
+## Task 6: Telegram `/config` and `/setconfig`
+
+**Files:**
+- Modify: `services/telegram/polling.py`
+- Test: `tests/unit/services/test_telegram.py`
+
+- [ ] **Step 1: Add command handlers and field list in `services/telegram/polling.py`**
+
+Add this module-level constant after the logger setup (after `services/telegram/polling.py:13`):
+
+```python
+_CONFIG_FIELDS = (
+    "target_pct",
+    "hodl_pct",
+    "k_act",
+    "min_margin",
+    "stop_pct_ll",
+    "stop_pct_lv",
+    "stop_pct_mv",
+    "stop_pct_hv",
+    "stop_pct_hh",
+)
+
+
+def _format_pair_config(item: dict) -> str:
+    k_act = item.get("k_act")
+    k_act_str = "None" if k_act is None else f"{k_act:g}"
+    return (
+        f"━━━ {item['pair']} ━━━\n"
+        f"target_pct: {item['target_pct']:g}\n"
+        f"hodl_pct: {item['hodl_pct']:g}\n"
+        f"k_act: {k_act_str}\n"
+        f"min_margin: {item['min_margin']:g}\n"
+        f"stop_pct: LL {item['stop_pct_ll']:g} | LV {item['stop_pct_lv']:g} | "
+        f"MV {item['stop_pct_mv']:g} | HV {item['stop_pct_hv']:g} | HH {item['stop_pct_hh']:g}"
+    )
+```
+
+Add the two command handlers (after `positions_command`, before `build_tg_app`):
+
+```python
+async def config_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not _check_auth(update):
+        return
+    try:
+        pair_filter = context.args[0].upper() if context.args else None
+        if pair_filter and pair_filter not in PAIRS:
+            await update.message.reply_text(f"❌ Unknown pair: {pair_filter}\nAvailable: {', '.join(PAIRS.keys())}")
+            return
+
+        url = f"/config/{pair_filter}" if pair_filter else "/config"
+        resp = await client.get(url)
+        resp.raise_for_status()
+        data = resp.json()
+        items = [data] if pair_filter else data
+        msg = "⚙️ Pair Config:\n\n" + "\n\n".join(_format_pair_config(item) for item in items)
+        await update.message.reply_text(msg)
+    except Exception as e:
+        logging.error(f"Error in config_command: {e}")
+        await update.message.reply_text(f"❌ Error fetching config: {e}")
+
+
+async def setconfig_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not _check_auth(update):
+        return
+    usage = "Usage: /setconfig <PAIR> <field> <value>\nFields: " + ", ".join(_CONFIG_FIELDS)
+    if len(context.args) != 3:
+        await update.message.reply_text(usage)
+        return
+
+    pair = context.args[0].upper()
+    field = context.args[1].lower()
+    value = context.args[2]
+
+    if pair not in PAIRS:
+        await update.message.reply_text(f"❌ Unknown pair: {pair}\nAvailable: {', '.join(PAIRS.keys())}")
+        return
+    if field not in _CONFIG_FIELDS:
+        await update.message.reply_text(f"❌ Unknown field: {field}\nFields: {', '.join(_CONFIG_FIELDS)}")
+        return
+
+    if value.lower() == "none":
+        if field != "k_act":
+            await update.message.reply_text("❌ Only k_act may be set to 'none'.")
+            return
+        body = {"k_act": None}
+    else:
+        body = {field: value}
+
+    try:
+        resp = await client.patch(f"/config/{pair}", json=body)
+        if resp.status_code == 422:
+            await update.message.reply_text(f"❌ Invalid: {resp.json().get('detail')}")
+            return
+        resp.raise_for_status()
+        await update.message.reply_text(f"✅ {pair} {field} updated.")
+    except Exception as e:
+        logging.error(f"Error in setconfig_command: {e}")
+        await update.message.reply_text(f"❌ Error updating config: {e}")
+```
+
+Register the handlers in `build_tg_app` (add before `return app`):
+
+```python
+    app.add_handler(CommandHandler("config", config_command))
+    app.add_handler(CommandHandler("setconfig", setconfig_command))
+```
+
+Add the two commands to the `help_command` text (extend the command list and example):
+
+```python
+        "/config [pair] - Show pair configuration (all or specific pair)\n"
+        "/setconfig <pair> <field> <value> - Update a config field\n"
+```
+
+- [ ] **Step 2: Write tests in `tests/unit/services/test_telegram.py`**
+
+Reuse the existing `MockUpdate`, `MockContext`, `_mock_client`, `_mock_response` helpers. Add:
+
+```python
+_CONFIG_ITEM = {
+    "pair": "XBTEUR", "target_pct": 30.0, "hodl_pct": 10.0, "k_act": 2.0, "min_margin": 0.0,
+    "stop_pct_ll": 0.9, "stop_pct_lv": 0.9, "stop_pct_mv": 0.9, "stop_pct_hv": 0.9, "stop_pct_hh": 0.9,
+}
+
+
+@pytest.mark.asyncio
+async def test_config_command_specific_pair(monkeypatch):
+    monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
+    monkeypatch.setattr(polling, "PAIRS", {"XBTEUR": {}})
+    monkeypatch.setattr(polling, "client", _mock_client(get=_mock_response(_CONFIG_ITEM)))
+
+    update = MockUpdate()
+    await polling.config_command(update, MockContext(args=["XBTEUR"]))
+
+    assert "XBTEUR" in update.message.replies[0]
+    assert "k_act: 2" in update.message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_setconfig_command_patches_single_field(monkeypatch):
+    monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
+    monkeypatch.setattr(polling, "PAIRS", {"XBTEUR": {}})
+    mock = _mock_client()
+    mock.patch = __import__("unittest").mock.AsyncMock(return_value=_mock_response({**_CONFIG_ITEM, "target_pct": 25.0}))
+    monkeypatch.setattr(polling, "client", mock)
+
+    update = MockUpdate()
+    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "target_pct", "25"]))
+
+    mock.patch.assert_called_once_with("/config/XBTEUR", json={"target_pct": "25"})
+    assert "✅" in update.message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_setconfig_command_k_act_none_sends_null(monkeypatch):
+    monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
+    monkeypatch.setattr(polling, "PAIRS", {"XBTEUR": {}})
+    mock = _mock_client()
+    mock.patch = __import__("unittest").mock.AsyncMock(return_value=_mock_response({**_CONFIG_ITEM, "k_act": None}))
+    monkeypatch.setattr(polling, "client", mock)
+
+    update = MockUpdate()
+    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "k_act", "none"]))
+
+    mock.patch.assert_called_once_with("/config/XBTEUR", json={"k_act": None})
+
+
+@pytest.mark.asyncio
+async def test_setconfig_command_bad_arity_shows_usage(monkeypatch):
+    monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
+    update = MockUpdate()
+    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "target_pct"]))
+    assert "Usage:" in update.message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_setconfig_command_unknown_field(monkeypatch):
+    monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
+    monkeypatch.setattr(polling, "PAIRS", {"XBTEUR": {}})
+    update = MockUpdate()
+    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "nonsense", "1"]))
+    assert "Unknown field" in update.message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_setconfig_command_none_rejected_for_non_k_act(monkeypatch):
+    monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
+    monkeypatch.setattr(polling, "PAIRS", {"XBTEUR": {}})
+    update = MockUpdate()
+    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "target_pct", "none"]))
+    assert "Only k_act" in update.message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_config_command_rejects_unauthorized(monkeypatch):
+    monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
+    update = MockUpdate(user_id=999)
+    await polling.config_command(update, MockContext())
+    assert update.message.replies == []
+```
+
+- [ ] **Step 3: Run the telegram tests**
+
+Run: `PYTHONPATH=. pytest tests/unit/services/test_telegram.py -v`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add services/telegram/polling.py tests/unit/services/test_telegram.py
+git commit -m "feat(telegram): /config and /setconfig commands"
+```
+
+---
+
+## Task 7: Docs, `.env`, and full verification
+
+**Files:**
+- Modify: `.env.example`, `docs/configuration.md`, `CLAUDE.md`, `docs/ROADMAP.md`
+
+- [ ] **Step 1: Drop per-side activation vars from `.env.example`**
+
+Remove any lines matching `*_SELL_K_ACT`, `*_BUY_K_ACT`, `*_SELL_MIN_MARGIN`, `*_BUY_MIN_MARGIN`. Ensure each pair documents only single `<PAIR>_K_ACT` and `<PAIR>_MIN_MARGIN`. (Search the file for `SELL_K_ACT` / `BUY_K_ACT` / `SELL_MIN_MARGIN` / `BUY_MIN_MARGIN` and delete those lines; keep `<PAIR>_K_ACT=` and `<PAIR>_MIN_MARGIN=`.)
+
+- [ ] **Step 2: Update `docs/configuration.md`**
+
+In the per-pair parameters section, remove the `PAIR_SELL_K_ACT` / `PAIR_BUY_K_ACT` / `PAIR_SELL_MIN_MARGIN` / `PAIR_BUY_MIN_MARGIN` variants and state that `K_ACT` and `MIN_MARGIN` are single per pair. Add a short subsection: these params (plus `TARGET_PCT`, `HODL_PCT`, `STOP_PCT_<level>`) are DB-authoritative once seeded — editable at runtime via `GET/PATCH /config/{pair}` and Telegram `/config` + `/setconfig`; `.env` seeds them on first boot only.
+
+- [ ] **Step 3: Update `CLAUDE.md`**
+
+- In the Database section, change "Six ORM models" to "Seven ORM models" and add `PairConfig` to the list; document the `pair_config` table (DB-authoritative per-pair config, seeded once from `.env`).
+- In the Configuration section, replace the `PAIR_K_ACT (or PAIR_SELL_K_ACT / PAIR_BUY_K_ACT)` line with a single `PAIR_K_ACT` (note per-side variants removed) and likewise `PAIR_MIN_MARGIN`.
+- Add three entries to the **Design choices** section:
+  - **Dynamic pair config is DB-authoritative, seeded once from `.env`** (a dedicated typed `pair_config` table over the generic `BotControl` store; `.env` becomes a one-time seed).
+  - **`stop_pct` changes recalc at the next session via a runtime dirty flag** (heavy calibration stays in the scheduler thread, never the request path).
+  - **`k_act`/`min_margin` are single per pair** (`K_STOP` stays per-side because it is derived).
+
+- [ ] **Step 4: Tick the ROADMAP Phase 1 checkboxes**
+
+In `docs/ROADMAP.md` Phase 1, mark the scope checkboxes complete (`- [x]`) as each lands; at minimum mark them all complete here at the end.
+
+- [ ] **Step 5: Run the full unit suite + lint + format**
+
+Run: `PYTHONPATH=. pytest tests/unit/ && python -m ruff check . && python -m ruff format --check .`
+Expected: PASS, coverage ≥ 80%.
+
+- [ ] **Step 6: Run the migration locally to confirm it applies**
+
+Run: `docker compose -f docker-compose.test.yml run --rm test alembic upgrade head`
+Expected: migration `20260616_01` applies cleanly; `pair_config` table created.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .env.example docs/configuration.md CLAUDE.md docs/ROADMAP.md
+git commit -m "docs: dynamic pair config + single k_act/min_margin"
+```
+
+---
+
+## Self-review notes (verification against the spec)
+
+- **Source of truth (DB-authoritative, seed once):** Task 2 (table) + Task 4 (`load_or_seed`) + Task 5 Step 3 (lifespan call).
+- **Structured per-pair API:** Task 5 (`GET /config`, `GET /config/{pair}`, `PATCH /config/{pair}`).
+- **Telegram flat one-field-per-command:** Task 6.
+- **Full per-side collapse incl. engine:** Task 1 (engine, config, validation, parameters_manager, positions_manager, backtest, optimizer).
+- **`stop_pct` recalc next session via dirty flag:** Task 3.
+- **Atomic validation, cross-pair target sum, persist-then-apply:** Task 1 (`normalize_pair_config` / `target_sum_error`) + Task 4 (`apply_patch`).
+- **Error handling (404 / 422 / persist-untouched):** Task 5 (route) + Task 4 (store) + Task 6 (telegram).
+- **Testing across store/validation/API/telegram/scheduler/collapse + migration parity:** Tasks 1–6 tests + Task 7 Steps 5–6.

--- a/docs/specs/dynamic-pair-config-design.md
+++ b/docs/specs/dynamic-pair-config-design.md
@@ -1,6 +1,5 @@
 # Dynamic Pair Configuration — Design
 
-**Date:** 2026-06-16
 **Status:** Approved (brainstorming) — ready for implementation plan
 **Roadmap:** V3 Phase 1 (regime filter moves to Phase 2)
 

--- a/docs/superpowers/specs/2026-06-16-dynamic-pair-config-design.md
+++ b/docs/superpowers/specs/2026-06-16-dynamic-pair-config-design.md
@@ -1,0 +1,285 @@
+# Dynamic Pair Configuration — Design
+
+**Date:** 2026-06-16
+**Status:** Approved (brainstorming) — ready for implementation plan
+**Roadmap:** V3 Phase 1 (regime filter moves to Phase 2)
+
+## Goal
+
+Make the pair-specific trading parameters currently fixed in `.env` —
+`target_pct`, `hodl_pct`, `k_act`, `min_margin`, and the volatility-based stop
+percentiles (`stop_pct_<level>`) — editable at runtime through both the HTTP API
+and Telegram, with changes taking effect automatically on the next bot session,
+no restart required.
+
+A secondary, intentional cleanup ships with this work: `k_act` and `min_margin`
+collapse from per-side (`buy`/`sell`) to a single value per pair, aligning the
+live config with how the optimizer already treats them.
+
+## Why
+
+These parameters are the main strategy knobs. Today, tuning any of them requires
+editing `.env` and restarting the `botc` container — slow, and it interrupts the
+trading loop. Exposing them through the existing API + Telegram surfaces (the
+same pattern as `/control/pause`) lets the operator retune live and lets the
+optimizer's recommendations be applied without a redeploy.
+
+The per-side collapse removes an existing inconsistency: the optimizer already
+applies one `k_act`/`min_margin` to both sides and emits a single
+`PAIR_K_ACT`/`PAIR_MIN_MARGIN`, while the live config still carries
+`PAIR_SELL_/BUY_` variants and a per-side `SidePolicy` in the engine. `K_STOP`
+stays per-side because it is *derived* from up/down-trend structural events.
+
+## Decisions (resolved during brainstorming)
+
+| Decision | Choice |
+| --- | --- |
+| Source of truth | **DB authoritative, seeded once from `.env`.** A new `pair_config` table. After seeding, `.env` edits to these params are ignored. |
+| API shape | **Structured per-pair.** `GET /config`, `GET /config/{pair}`, `PATCH /config/{pair}` (partial, validated as a unit). |
+| Telegram write | **Flat one-field-per-command.** `/config [pair]` to read, `/setconfig <pair> <field> <value>` to write. |
+| Per-side collapse | **Full collapse including the engine.** Single `k_act`/`min_margin` everywhere; `K_STOP` stays per-side. Drop `PAIR_SELL_/BUY_` env vars. |
+| `stop_pct` reload | **Recalc at the next bot session** via a per-pair dirty flag — not synchronous in the request, not waiting the full `PARAM_SESSIONS` cycle. |
+
+## Architecture
+
+### Data model — `pair_config` table
+
+One row per pair, typed columns mapping 1:1 to the structured API:
+
+```
+pair (PK, str)
+target_pct   (float)
+hodl_pct     (float)
+k_act        (float, nullable)
+min_margin   (float)
+stop_pct_ll  (float)
+stop_pct_lv  (float)
+stop_pct_mv  (float)
+stop_pct_hv  (float)
+stop_pct_hh  (float)
+updated_at   (timestamp)
+updated_by   (str, nullable)
+```
+
+A dedicated typed table (not the generic `BotControl` key/value store) because it
+validates as a row, is self-documenting, and reads cleanly in SQL/Grafana.
+Derived `K_STOP` is **not** stored — it stays computed by
+`calculate_trading_parameters`.
+
+Per CLAUDE.md, **both** the ORM model in `core/database.py` and a new Alembic
+migration under `scripts/migrations/versions/` are updated together (CI builds
+the schema from migrations).
+
+### Source of truth — seed-once / DB-authoritative
+
+At startup (`api/app.py` lifespan, after `validate_config` normalizes env into the
+live dicts):
+
+- For each pair, if a `pair_config` row exists → load its typed values into the
+  live dicts (`TRADING_PARAMS`, `ASSET_ALLOCATION`, `STOP_PERCENTILES`),
+  overriding the env-seeded values.
+- If no row exists → insert one seeded from the validated env values.
+
+So `.env` is the one-time seed; thereafter the DB wins. A pair added to `.env`
+later (no row yet) is seeded on next startup; once a row exists, `.env` edits to
+that pair are ignored.
+
+### New module — `core/config_store.py`
+
+Single owner of dynamic config. Consumers keep reading the existing module-level
+dicts unchanged; the store keeps those dicts current.
+
+- `load_or_seed()` — startup sync described above.
+- `get_pair(pair)` / `get_all()` — typed reads for the API.
+- `apply_patch(pair, fields, updated_by)` — validate → persist → update live dicts
+  → flag dirty (if a `stop_pct` changed). Atomic; see Validation.
+
+A module lock makes each multi-field patch atomic against the scheduler's reads.
+
+### Live propagation
+
+- `k_act`, `min_margin`, `target_pct`, `hodl_pct` are read live from the dicts
+  every tick. Updating the dict in place is enough — effective next session.
+- `stop_pct_<level>` only feeds `K_STOP` inside `calculate_trading_parameters`.
+  `apply_patch` calls `runtime.mark_config_dirty(pair)` when any `stop_pct`
+  changes.
+
+**Runtime dirty flag** (`core/runtime.py`, under its existing lock):
+`mark_config_dirty(pair)` and `pop_config_dirty(pair)` (returns + clears
+atomically).
+
+**Scheduler change** (`core/scheduler.py`, step 2 of the per-pair loop). The
+recalc condition becomes:
+
+```python
+if (tick % PARAM_SESSIONS == 0) or runtime.pop_config_dirty(pair):
+    calculate_trading_parameters(pair)
+```
+
+So a `stop_pct` change recomputes `K_STOP` at the next session
+(~`SLEEPING_INTERVAL`), in the scheduler thread where calibration already runs —
+never in the API request path.
+
+### Concurrency
+
+`apply_patch` holds the `config_store` lock for validate→persist→dict-update.
+Per-key dict assignment is atomic under the GIL and the scheduler reads at tick
+boundaries, so a patch landing mid-tick cannot tear a pair's config. Ordering is
+**persist-then-update**: if the DB write fails, the in-memory dicts are left
+untouched and the patch returns an error.
+
+## API & Telegram surface
+
+### HTTP — `api/routes/config.py`
+
+Registered like the other routers; all endpoints require the `X-Api-Token`
+header.
+
+- `GET /config` → list of all pairs' typed config.
+- `GET /config/{pair}` → one pair (404 if unknown).
+- `PATCH /config/{pair}` → partial body; validates the pair as a unit, persists,
+  updates live dicts, flags dirty if `stop_pct` changed; returns the new state.
+
+Request/response models in `api/schemas.py` (`PairConfig`, `PairConfigPatch`).
+All patch fields optional; `k_act` explicitly nullable (null = use the
+`K_STOP + MIN_MARGIN` path).
+
+```
+PATCH /config/XBTEUR
+{ "k_act": 2.0, "target_pct": 30, "stop_pct_hh": 0.95 }
+```
+
+### Telegram — `services/telegram/polling.py`
+
+Thin REST callers, auth via existing `_check_auth`.
+
+- `/config [pair]` → GET and pretty-print (all pairs, or one).
+- `/setconfig <pair> <field> <value>` → one field per call → single-field PATCH.
+
+Flat field names (side folded out): `target_pct`, `hodl_pct`, `k_act`,
+`min_margin`, `stop_pct_ll`, `stop_pct_lv`, `stop_pct_mv`, `stop_pct_hv`,
+`stop_pct_hh`. `/setconfig` with bad arity or an unknown field replies with usage
+plus the valid field list; `k_act none` sends `null`. Both commands are added to
+`/help` and `build_tg_app()`.
+
+## The k_act/min_margin per-side collapse
+
+Restructure `TRADING_PARAMS[pair]` so configured params are pair-level and only
+derived `K_STOP` stays per-side:
+
+```python
+TRADING_PARAMS[pair] = {
+    "K_ACT": float | None,
+    "MIN_MARGIN": float,
+    "K_STOP": {"buy": {level: k}, "sell": {level: k}},  # derived
+}
+```
+
+Files touched:
+
+- **`core/config.py`** — `_build_trading_params` reads only `PAIR_K_ACT` /
+  `PAIR_MIN_MARGIN` (drop `PAIR_SELL_/BUY_` variants); no buy/sell split for the
+  configured pair.
+- **`core/validation.py`** — validate `k_act`/`min_margin` once per pair; extract
+  per-pair normalize+validate into a reusable function (see Validation).
+- **`trading/parameters_manager.py`** — `calculate_trading_parameters` writes
+  `["K_STOP"]["buy"/"sell"]`; `get_k_stop` reads
+  `TRADING_PARAMS[pair]["K_STOP"][side]`.
+- **`trading/positions_manager.py`** — `calculate_activation_distance` reads
+  pair-level `K_ACT`/`MIN_MARGIN`.
+- **`trading/engine.py`** — remove `SidePolicy`; `EngineConfig` gains
+  `k_act: float | None` and `min_margin: float`; `PairCalibration` keeps
+  `k_stop_buy`/`k_stop_sell`; `activation_distance` uses `cfg.k_act`/
+  `cfg.min_margin`.
+- **`trading/optimizer/search.py`** — `_apply_candidate` builds `EngineConfig`
+  with single values; `current_params` reads `TRADING_PARAMS[pair]["K_ACT"]`.
+- **`trading/backtest.py`** + **`api/schemas.py`** — backtest request collapses
+  any per-side `k_act`/`min_margin` to single fields; `EngineConfig` built
+  accordingly.
+- **`.env.example`**, **`docs/configuration.md`** — drop
+  `PAIR_SELL_/BUY_K_ACT/MIN_MARGIN`; document `PAIR_K_ACT`/`PAIR_MIN_MARGIN` as
+  single.
+
+This is a breaking `.env` schema change (per-side variants removed), consistent
+with the "seed once from env" model — the seed reads only the single keys.
+
+## Validation
+
+Extract the per-pair logic currently inline in `validate_pair_params` into a
+reusable function:
+
+```python
+# core/validation.py
+def normalize_pair_config(pair, raw: dict, *, all_targets: dict[str, float]) -> tuple[dict, list[str]]
+```
+
+It returns typed values + an error list, applying the existing rules in one place:
+
+- `k_act`: float ≥ 0, or `None` (falls through to the `K_STOP + MIN_MARGIN`
+  path).
+- `min_margin`: float ≥ 0; **required** when `k_act` is `None`; ignored
+  (normalized to `0.0`) when `k_act` is set.
+- `target_pct`, `hodl_pct`: float in `[0, 100]`.
+- `stop_pct_<level>`: float in `[0, 1]`, default `0.90` when unset.
+- Cross-pair: sum of `target_pct` across all pairs ≤ 100, checked against the
+  *proposed* state (other pairs' current targets + this patch).
+
+Both startup (`validate_config`) and runtime (`config_store.apply_patch`) call
+this same function — startup over all pairs, a patch over the one pair plus the
+others' current targets for the sum check.
+
+`apply_patch` is **atomic**: validate the merged pair first; on any error,
+persist nothing, touch no dict, return the error list. Then persist, then update
+dicts, then flag dirty.
+
+### Error handling
+
+- Unknown pair → 404.
+- Validation failure (bad type, out of range, `target_pct` sum > 100, or
+  `min_margin` missing when `k_act` is null) → 422 with a message Telegram
+  surfaces verbatim.
+- DB write failure → 500; dicts untouched.
+- Telegram: bad arity / unknown field → usage + valid field list.
+
+## Testing
+
+Unit tests (`tests/unit/`, no external calls, monkeypatch DB/Kraken at import
+site), targeting the 80% coverage gate:
+
+- **`core/config_store`**: seed-when-absent vs load-when-present; `apply_patch`
+  happy path updates dict + persists; invalid patch leaves dict + DB untouched;
+  `stop_pct` change sets the dirty flag, others don't.
+- **`core/validation`**: `normalize_pair_config` rules incl.
+  `min_margin`-required-when-`k_act`-null, ranges, and cross-pair target-sum
+  rejection.
+- **`api/routes/config`**: GET all / GET pair / 404 unknown / PATCH success / 422
+  invalid (monkeypatched store).
+- **Telegram**: `/config` and `/setconfig` handlers — read formatting,
+  single-field PATCH dispatch, bad arity / unknown field / `k_act none`, auth
+  rejection.
+- **Scheduler**: recalc fires when `pop_config_dirty` returns true even if the
+  tick counter hasn't hit `PARAM_SESSIONS`.
+- **Collapse regression**: `positions_manager`, `engine`, `optimizer`,
+  `backtest` read single `k_act`/`min_margin`; update existing tests referencing
+  the per-side structure.
+- **Migration**: `pair_config` ORM model / Alembic migration parity.
+
+## Out of scope
+
+- The trend/chop regime filter (V3 Phase 2).
+- Editing global (non-pair) settings (`SLEEPING_INTERVAL`, `PARAM_SESSIONS`,
+  etc.) at runtime.
+- Tolerance/clustering relaxations in the optimizer.
+- A config change history/audit log beyond `updated_at`/`updated_by`.
+
+## Design choices to record in CLAUDE.md
+
+On implementation, add to the **Design choices** section:
+
+- **Dynamic pair config is DB-authoritative, seeded once from `.env`.** Why a
+  dedicated typed `pair_config` table over the generic `BotControl` store, and
+  why `.env` becomes a one-time seed.
+- **`stop_pct` changes recalc at the next session via a runtime dirty flag**, not
+  synchronously in the request — keeps heavy calibration in the scheduler thread.
+- **`k_act`/`min_margin` are single per pair** (`K_STOP` stays per-side because
+  it is derived).

--- a/scripts/migrations/versions/20260616_01_pair_config.py
+++ b/scripts/migrations/versions/20260616_01_pair_config.py
@@ -1,0 +1,47 @@
+"""Phase 1 (V3): add pair_config table for dynamic per-pair configuration.
+
+Revision ID: 20260616_01
+Revises: 20260608_01
+Create Date: 2026-06-16 00:00:00
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20260616_01"
+down_revision = "20260608_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pair_config",
+        sa.Column("pair", sa.Text(), primary_key=True, nullable=False),
+        sa.Column("target_pct", sa.Numeric(6, 3), nullable=False, server_default="0"),
+        sa.Column("hodl_pct", sa.Numeric(6, 3), nullable=False, server_default="0"),
+        sa.Column("k_act", sa.Numeric(10, 4), nullable=True),
+        sa.Column("min_margin", sa.Numeric(12, 8), nullable=False, server_default="0"),
+        sa.Column("stop_pct_ll", sa.Numeric(4, 3), nullable=False, server_default="0.90"),
+        sa.Column("stop_pct_lv", sa.Numeric(4, 3), nullable=False, server_default="0.90"),
+        sa.Column("stop_pct_mv", sa.Numeric(4, 3), nullable=False, server_default="0.90"),
+        sa.Column("stop_pct_hv", sa.Numeric(4, 3), nullable=False, server_default="0.90"),
+        sa.Column("stop_pct_hh", sa.Numeric(4, 3), nullable=False, server_default="0.90"),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_by", sa.Text(), nullable=True),
+        sa.CheckConstraint("target_pct >= 0 AND target_pct <= 100", name="ck_pair_config_target_pct_range"),
+        sa.CheckConstraint("hodl_pct >= 0 AND hodl_pct <= 100", name="ck_pair_config_hodl_pct_range"),
+        sa.CheckConstraint("k_act IS NULL OR k_act >= 0", name="ck_pair_config_k_act_nonneg"),
+        sa.CheckConstraint("min_margin >= 0", name="ck_pair_config_min_margin_nonneg"),
+        sa.CheckConstraint("stop_pct_ll >= 0 AND stop_pct_ll <= 1", name="ck_pair_config_stop_ll_range"),
+        sa.CheckConstraint("stop_pct_lv >= 0 AND stop_pct_lv <= 1", name="ck_pair_config_stop_lv_range"),
+        sa.CheckConstraint("stop_pct_mv >= 0 AND stop_pct_mv <= 1", name="ck_pair_config_stop_mv_range"),
+        sa.CheckConstraint("stop_pct_hv >= 0 AND stop_pct_hv <= 1", name="ck_pair_config_stop_hv_range"),
+        sa.CheckConstraint("stop_pct_hh >= 0 AND stop_pct_hh <= 1", name="ck_pair_config_stop_hh_range"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("pair_config")

--- a/services/telegram/polling.py
+++ b/services/telegram/polling.py
@@ -12,6 +12,32 @@ logging.getLogger("httpcore").setLevel(logging.WARNING)
 logging.getLogger("telegram").setLevel(logging.WARNING)
 logging.getLogger("telegram.bot").setLevel(logging.WARNING)
 
+_CONFIG_FIELDS = (
+    "target_pct",
+    "hodl_pct",
+    "k_act",
+    "min_margin",
+    "stop_pct_ll",
+    "stop_pct_lv",
+    "stop_pct_mv",
+    "stop_pct_hv",
+    "stop_pct_hh",
+)
+
+
+def _format_pair_config(item: dict) -> str:
+    k_act = item.get("k_act")
+    k_act_str = "None" if k_act is None else f"{k_act:g}"
+    return (
+        f"━━━ {item['pair']} ━━━\n"
+        f"target_pct: {item['target_pct']:g}\n"
+        f"hodl_pct: {item['hodl_pct']:g}\n"
+        f"k_act: {k_act_str}\n"
+        f"min_margin: {item['min_margin']:g}\n"
+        f"stop_pct: LL {item['stop_pct_ll']:g} | LV {item['stop_pct_lv']:g} | "
+        f"MV {item['stop_pct_mv']:g} | HV {item['stop_pct_hv']:g} | HH {item['stop_pct_hh']:g}"
+    )
+
 
 def _check_auth(update: Update) -> bool:
     if not TELEGRAM_USER_ID:
@@ -41,6 +67,8 @@ async def help_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "/resume - Resume bot operations\n"
         "/market [pair] - Current market data (all or specific pair)\n"
         "/positions [pair] - Open positions (all or specific pair)\n"
+        "/config [pair] - Show pair configuration (all or specific pair)\n"
+        "/setconfig <pair> <field> <value> - Update a config field\n"
         "/help - Show this help\n\n"
         f"Configured pairs: {pairs_list}\n"
         "Example: /market XBTEUR"
@@ -201,6 +229,70 @@ async def positions_command(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         await update.message.reply_text(f"❌ Error fetching positions: {e}")
 
 
+async def config_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not _check_auth(update):
+        return
+    try:
+        pair_filter = context.args[0].upper() if context.args else None
+        if pair_filter and pair_filter not in PAIRS:
+            await update.message.reply_text(f"❌ Unknown pair: {pair_filter}\nAvailable: {', '.join(PAIRS.keys())}")
+            return
+
+        url = f"/config/{pair_filter}" if pair_filter else "/config"
+        resp = await client.get(url)
+        resp.raise_for_status()
+        data = resp.json()
+        items = [data] if pair_filter else data
+        msg = "⚙️ Pair Config:\n\n" + "\n\n".join(_format_pair_config(item) for item in items)
+        await update.message.reply_text(msg)
+    except Exception as e:
+        logging.error(f"Error in config_command: {e}")
+        await update.message.reply_text(f"❌ Error fetching config: {e}")
+
+
+async def setconfig_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    if not _check_auth(update):
+        return
+    usage = "Usage: /setconfig <PAIR> <field> <value>\nFields: " + ", ".join(_CONFIG_FIELDS)
+    if len(context.args) != 3:
+        await update.message.reply_text(usage)
+        return
+
+    pair = context.args[0].upper()
+    field = context.args[1].lower()
+    value = context.args[2]
+
+    if pair not in PAIRS:
+        await update.message.reply_text(f"❌ Unknown pair: {pair}\nAvailable: {', '.join(PAIRS.keys())}")
+        return
+    if field not in _CONFIG_FIELDS:
+        await update.message.reply_text(f"❌ Unknown field: {field}\nFields: {', '.join(_CONFIG_FIELDS)}")
+        return
+
+    if value.lower() == "none":
+        if field != "k_act":
+            await update.message.reply_text("❌ Only k_act may be set to 'none'.")
+            return
+        body = {"k_act": None}
+    else:
+        try:
+            body = {field: float(value)}
+        except ValueError:
+            await update.message.reply_text(f"❌ Invalid value for {field}: '{value}' is not a number.")
+            return
+
+    try:
+        resp = await client.patch(f"/config/{pair}", json=body)
+        if resp.status_code == 422:
+            await update.message.reply_text(f"❌ Invalid: {resp.json().get('detail')}")
+            return
+        resp.raise_for_status()
+        await update.message.reply_text(f"✅ {pair} {field} updated.")
+    except Exception as e:
+        logging.error(f"Error in setconfig_command: {e}")
+        await update.message.reply_text(f"❌ Error updating config: {e}")
+
+
 def build_tg_app() -> Application:
     app = ApplicationBuilder().token(TELEGRAM_TOKEN).build()
     app.add_handler(CommandHandler("help", help_command))
@@ -209,4 +301,6 @@ def build_tg_app() -> Application:
     app.add_handler(CommandHandler("resume", resume_command))
     app.add_handler(CommandHandler("market", market_command))
     app.add_handler(CommandHandler("positions", positions_command))
+    app.add_handler(CommandHandler("config", config_command))
+    app.add_handler(CommandHandler("setconfig", setconfig_command))
     return app

--- a/services/telegram/polling.py
+++ b/services/telegram/polling.py
@@ -12,17 +12,18 @@ logging.getLogger("httpcore").setLevel(logging.WARNING)
 logging.getLogger("telegram").setLevel(logging.WARNING)
 logging.getLogger("telegram.bot").setLevel(logging.WARNING)
 
-_CONFIG_FIELDS = (
-    "target_pct",
-    "hodl_pct",
-    "k_act",
-    "min_margin",
-    "stop_pct_ll",
-    "stop_pct_lv",
-    "stop_pct_mv",
-    "stop_pct_hv",
-    "stop_pct_hh",
-)
+_FIELD_MAP = {
+    "target": "target_pct",
+    "hodl": "hodl_pct",
+    "kact": "k_act",
+    "margin": "min_margin",
+    "stop-ll": "stop_pct_ll",
+    "stop-lv": "stop_pct_lv",
+    "stop-mv": "stop_pct_mv",
+    "stop-hv": "stop_pct_hv",
+    "stop-hh": "stop_pct_hh",
+}
+_CONFIG_FIELDS = tuple(_FIELD_MAP)
 
 
 def _format_pair_config(item: dict) -> str:
@@ -251,7 +252,16 @@ async def config_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 async def setconfig_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not _check_auth(update):
         return
-    usage = "Usage: /setconfig <PAIR> <field> <value>\nFields: " + ", ".join(_CONFIG_FIELDS)
+    usage = (
+        "Usage: /setconfig <PAIR> <field> <value>\n\n"
+        "Fields:\n"
+        "  target       Target allocation %\n"
+        "  hodl         Hodl allocation %\n"
+        "  kact         Activation ATR multiplier ('none' to disable)\n"
+        "  margin       Min price margin from entry\n"
+        "  stop-ll/lv/mv/hv/hh   K-stop percentile per volatility level\n\n"
+        "Example: /setconfig XBTEUR stop-mv 0.6"
+    )
     if len(context.args) != 3:
         await update.message.reply_text(usage)
         return
@@ -267,14 +277,15 @@ async def setconfig_command(update: Update, context: ContextTypes.DEFAULT_TYPE) 
         await update.message.reply_text(f"❌ Unknown field: {field}\nFields: {', '.join(_CONFIG_FIELDS)}")
         return
 
+    api_field = _FIELD_MAP[field]
     if value.lower() == "none":
-        if field != "k_act":
-            await update.message.reply_text("❌ Only k_act may be set to 'none'.")
+        if field != "kact":
+            await update.message.reply_text("❌ Only kact may be set to 'none'.")
             return
-        body = {"k_act": None}
+        body = {api_field: None}
     else:
         try:
-            body = {field: float(value)}
+            body = {api_field: float(value)}
         except ValueError:
             await update.message.reply_text(f"❌ Invalid value for {field}: '{value}' is not a number.")
             return

--- a/services/telegram/polling.py
+++ b/services/telegram/polling.py
@@ -30,12 +30,10 @@ def _format_pair_config(item: dict) -> str:
     k_act_str = "None" if k_act is None else f"{k_act:g}"
     return (
         f"━━━ {item['pair']} ━━━\n"
-        f"target_pct: {item['target_pct']:g}\n"
-        f"hodl_pct: {item['hodl_pct']:g}\n"
-        f"k_act: {k_act_str}\n"
-        f"min_margin: {item['min_margin']:g}\n"
-        f"stop_pct: LL {item['stop_pct_ll']:g} | LV {item['stop_pct_lv']:g} | "
-        f"MV {item['stop_pct_mv']:g} | HV {item['stop_pct_hv']:g} | HH {item['stop_pct_hh']:g}"
+        f"Target %: {item['target_pct']:g}  |  Hodl %: {item['hodl_pct']:g}\n"
+        f"K-act: {k_act_str}  |  Min margin: {item['min_margin']:g}\n"
+        f"Stop percentiles: LL {item['stop_pct_ll']:g} -  LV {item['stop_pct_lv']:g}  -  MV {item['stop_pct_mv']:g}\n"
+        f"HV {item['stop_pct_hv']:g}  -  HH {item['stop_pct_hh']:g}"
     )
 
 

--- a/tests/unit/api/test_api.py
+++ b/tests/unit/api/test_api.py
@@ -95,7 +95,7 @@ def test_full_app_rejects_request_without_token(monkeypatch):
     """Routers mounted on api_app.app must enforce verify_token via _auth dep."""
     monkeypatch.setattr(api_app, "API_SECRET_TOKEN", "secret-xyz")
     client = TestClient(api_app.app)
-    for path in ("/balance", "/status", "/market", "/positions"):
+    for path in ("/balance", "/status", "/market", "/positions", "/config"):
         resp = client.get(path)
         assert resp.status_code == 401, f"{path} did not require auth"
     resp = client.post("/control/pause")
@@ -158,6 +158,7 @@ def test_lifespan_db_connection_fails(monkeypatch):
 def test_lifespan_success_starts_and_stops_scheduler(monkeypatch):
     monkeypatch.setattr(api_app, "validate_config", lambda: True)
     monkeypatch.setattr(api_app.db, "check_database_connection", lambda: True)
+    monkeypatch.setattr(api_app.config_store, "load_or_seed", lambda: None)
     monkeypatch.setattr(api_app, "scheduler", None)
 
     mock_scheduler = MagicMock()

--- a/tests/unit/api/test_config_route.py
+++ b/tests/unit/api/test_config_route.py
@@ -1,0 +1,89 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import core.config_store as config_store
+from api.routes import config as config_route
+
+_PAIRS = {"XBTEUR": {}, "ETHEUR": {}}
+_FLAT = {
+    "target_pct": 30.0,
+    "hodl_pct": 10.0,
+    "k_act": 2.0,
+    "min_margin": 0.0,
+    "stop_pct_ll": 0.9,
+    "stop_pct_lv": 0.9,
+    "stop_pct_mv": 0.9,
+    "stop_pct_hv": 0.9,
+    "stop_pct_hh": 0.9,
+}
+
+
+def _client(monkeypatch):
+    monkeypatch.setattr(config_route, "PAIRS", _PAIRS)
+    app = FastAPI()
+    app.include_router(config_route.router)
+    return TestClient(app)
+
+
+def test_get_config_all(monkeypatch):
+    monkeypatch.setattr(config_store, "get_all", lambda: {p: dict(_FLAT) for p in _PAIRS})
+    body = _client(monkeypatch).get("/config").json()
+    pairs = {item["pair"] for item in body}
+    assert pairs == {"XBTEUR", "ETHEUR"}
+
+
+def test_get_config_pair(monkeypatch):
+    monkeypatch.setattr(config_store, "get_pair", lambda pair: dict(_FLAT))
+    body = _client(monkeypatch).get("/config/XBTEUR").json()
+    assert body["pair"] == "XBTEUR"
+    assert body["k_act"] == 2.0
+
+
+def test_get_config_unknown_pair_404(monkeypatch):
+    assert _client(monkeypatch).get("/config/DOGEUR").status_code == 404
+
+
+def test_patch_config_success(monkeypatch):
+    captured = {}
+
+    def _apply(pair, fields, updated_by=None):
+        captured["pair"] = pair
+        captured["fields"] = fields
+        return {**_FLAT, **fields}
+
+    monkeypatch.setattr(config_store, "apply_patch", _apply)
+    resp = _client(monkeypatch).patch("/config/XBTEUR", json={"target_pct": 25.0})
+    assert resp.status_code == 200
+    assert resp.json()["target_pct"] == 25.0
+    assert captured["fields"] == {"target_pct": 25.0}
+
+
+def test_patch_config_explicit_null_k_act_is_forwarded(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        config_store,
+        "apply_patch",
+        lambda pair, fields, updated_by=None: captured.update(fields) or {**_FLAT, "k_act": None, "min_margin": 0.001},
+    )
+    resp = _client(monkeypatch).patch("/config/XBTEUR", json={"k_act": None, "min_margin": 0.001})
+    assert resp.status_code == 200
+    assert captured["k_act"] is None
+
+
+def test_patch_config_validation_error_422(monkeypatch):
+    def _apply(pair, fields, updated_by=None):
+        raise config_store.ConfigValidationError(["XBTEUR_TARGET_PCT must be <= 100 (got 150)"])
+
+    monkeypatch.setattr(config_store, "apply_patch", _apply)
+    resp = _client(monkeypatch).patch("/config/XBTEUR", json={"target_pct": 99.0})
+    assert resp.status_code == 422
+    assert "TARGET_PCT" in resp.json()["detail"]
+
+
+def test_patch_config_empty_body_422(monkeypatch):
+    resp = _client(monkeypatch).patch("/config/XBTEUR", json={})
+    assert resp.status_code == 422
+
+
+def test_patch_config_unknown_pair_404(monkeypatch):
+    assert _client(monkeypatch).patch("/config/DOGEUR", json={"target_pct": 1.0}).status_code == 404

--- a/tests/unit/core/test_config_store.py
+++ b/tests/unit/core/test_config_store.py
@@ -1,0 +1,120 @@
+import pytest
+
+import core.config as config
+import core.config_store as config_store
+
+
+def _seed_dicts(monkeypatch, pairs):
+    monkeypatch.setattr(config, "PAIRS", pairs)
+    monkeypatch.setattr(config_store, "PAIRS", pairs)
+    monkeypatch.setattr(
+        config,
+        "TRADING_PARAMS",
+        {p: {"K_ACT": 2.0, "MIN_MARGIN": 0.0, "K_STOP": {"buy": {}, "sell": {}}} for p in pairs},
+    )
+    monkeypatch.setattr(config, "ASSET_ALLOCATION", {p: {"TARGET_PCT": 30.0, "HODL_PCT": 10.0} for p in pairs})
+    monkeypatch.setattr(
+        config,
+        "STOP_PERCENTILES",
+        {p: {lvl: 0.90 for lvl in config.VOLATILITY_LEVELS} for p in pairs},
+    )
+
+
+def test_load_or_seed_inserts_when_row_absent(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    monkeypatch.setattr(config_store.db, "load_all_pair_config", lambda: {})
+    saved = {}
+    monkeypatch.setattr(
+        config_store.db, "upsert_pair_config", lambda pair, values, updated_by=None: saved.update({pair: values})
+    )
+
+    config_store.load_or_seed()
+
+    assert saved["XBTEUR"]["k_act"] == 2.0
+    assert saved["XBTEUR"]["target_pct"] == 30.0
+
+
+def test_load_or_seed_loads_when_row_present(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    row = {
+        "pair": "XBTEUR", "target_pct": 40.0, "hodl_pct": 5.0, "k_act": None,
+        "min_margin": 0.002, "stop_pct_ll": 0.8, "stop_pct_lv": 0.8, "stop_pct_mv": 0.8,
+        "stop_pct_hv": 0.8, "stop_pct_hh": 0.9, "updated_at": None, "updated_by": None,
+    }
+    monkeypatch.setattr(config_store.db, "load_all_pair_config", lambda: {"XBTEUR": row})
+    monkeypatch.setattr(
+        config_store.db, "upsert_pair_config", lambda *a, **k: pytest.fail("should not seed when row present")
+    )
+
+    config_store.load_or_seed()
+
+    assert config.get_pair_config("XBTEUR")["target_pct"] == 40.0
+    assert config.get_pair_config("XBTEUR")["k_act"] is None
+    assert config.get_pair_config("XBTEUR")["min_margin"] == 0.002
+
+
+def test_apply_patch_unknown_pair_raises(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    with pytest.raises(config_store.UnknownPairError):
+        config_store.apply_patch("DOGEUR", {"target_pct": 1.0})
+
+
+def test_apply_patch_updates_dict_and_persists(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    saved = {}
+    monkeypatch.setattr(
+        config_store.db, "upsert_pair_config", lambda pair, values, updated_by=None: saved.update({pair: values})
+    )
+
+    result = config_store.apply_patch("XBTEUR", {"target_pct": 25.0}, updated_by="api")
+
+    assert result["target_pct"] == 25.0
+    assert config.get_pair_config("XBTEUR")["target_pct"] == 25.0
+    assert saved["XBTEUR"]["target_pct"] == 25.0
+
+
+def test_apply_patch_invalid_leaves_dict_and_db_untouched(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda *a, **k: pytest.fail("must not persist on invalid"))
+
+    with pytest.raises(config_store.ConfigValidationError):
+        config_store.apply_patch("XBTEUR", {"target_pct": 150.0})
+
+    assert config.get_pair_config("XBTEUR")["target_pct"] == 30.0  # unchanged
+
+
+def test_apply_patch_target_sum_over_100_rejected(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR", "ETHEUR"])  # each currently 30
+    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda *a, **k: pytest.fail("must not persist"))
+
+    with pytest.raises(config_store.ConfigValidationError) as exc:
+        config_store.apply_patch("XBTEUR", {"target_pct": 95.0})  # 95 + 30 > 100
+    assert any("TARGET_PCT" in e for e in exc.value.errors)
+
+
+def test_apply_patch_stop_pct_change_sets_dirty_flag(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda *a, **k: None)
+    marked = []
+    monkeypatch.setattr(config_store.runtime, "mark_config_dirty", lambda pair: marked.append(pair))
+
+    config_store.apply_patch("XBTEUR", {"stop_pct_hh": 0.95})
+    assert marked == ["XBTEUR"]
+
+
+def test_apply_patch_non_stop_change_does_not_set_dirty_flag(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda *a, **k: None)
+    marked = []
+    monkeypatch.setattr(config_store.runtime, "mark_config_dirty", lambda pair: marked.append(pair))
+
+    config_store.apply_patch("XBTEUR", {"target_pct": 20.0})
+    assert marked == []
+
+
+def test_apply_patch_k_act_null_keeps_min_margin(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])
+    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda *a, **k: None)
+    result = config_store.apply_patch("XBTEUR", {"k_act": None, "min_margin": 0.001})
+    assert result["k_act"] is None
+    assert result["min_margin"] == 0.001

--- a/tests/unit/core/test_config_store.py
+++ b/tests/unit/core/test_config_store.py
@@ -37,9 +37,18 @@ def test_load_or_seed_inserts_when_row_absent(monkeypatch):
 def test_load_or_seed_loads_when_row_present(monkeypatch):
     _seed_dicts(monkeypatch, ["XBTEUR"])
     row = {
-        "pair": "XBTEUR", "target_pct": 40.0, "hodl_pct": 5.0, "k_act": None,
-        "min_margin": 0.002, "stop_pct_ll": 0.8, "stop_pct_lv": 0.8, "stop_pct_mv": 0.8,
-        "stop_pct_hv": 0.8, "stop_pct_hh": 0.9, "updated_at": None, "updated_by": None,
+        "pair": "XBTEUR",
+        "target_pct": 40.0,
+        "hodl_pct": 5.0,
+        "k_act": None,
+        "min_margin": 0.002,
+        "stop_pct_ll": 0.8,
+        "stop_pct_lv": 0.8,
+        "stop_pct_mv": 0.8,
+        "stop_pct_hv": 0.8,
+        "stop_pct_hh": 0.9,
+        "updated_at": None,
+        "updated_by": None,
     }
     monkeypatch.setattr(config_store.db, "load_all_pair_config", lambda: {"XBTEUR": row})
     monkeypatch.setattr(
@@ -75,7 +84,9 @@ def test_apply_patch_updates_dict_and_persists(monkeypatch):
 
 def test_apply_patch_invalid_leaves_dict_and_db_untouched(monkeypatch):
     _seed_dicts(monkeypatch, ["XBTEUR"])
-    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda *a, **k: pytest.fail("must not persist on invalid"))
+    monkeypatch.setattr(
+        config_store.db, "upsert_pair_config", lambda *a, **k: pytest.fail("must not persist on invalid")
+    )
 
     with pytest.raises(config_store.ConfigValidationError):
         config_store.apply_patch("XBTEUR", {"target_pct": 150.0})
@@ -118,3 +129,12 @@ def test_apply_patch_k_act_null_keeps_min_margin(monkeypatch):
     result = config_store.apply_patch("XBTEUR", {"k_act": None, "min_margin": 0.001})
     assert result["k_act"] is None
     assert result["min_margin"] == 0.001
+
+
+def test_apply_patch_k_act_null_without_margin_rejected_when_current_margin_is_zero(monkeypatch):
+    _seed_dicts(monkeypatch, ["XBTEUR"])  # current: k_act=2.0, min_margin=0.0
+    monkeypatch.setattr(config_store.db, "upsert_pair_config", lambda *a, **k: pytest.fail("must not persist"))
+
+    with pytest.raises(config_store.ConfigValidationError) as exc:
+        config_store.apply_patch("XBTEUR", {"k_act": None})  # no min_margin
+    assert "min_margin" in exc.value.errors[0].lower()

--- a/tests/unit/core/test_database.py
+++ b/tests/unit/core/test_database.py
@@ -962,3 +962,44 @@ def test_finalize_session_swallows_snapshot_write_error(monkeypatch, caplog):
     )
 
     assert "Error saving latest_balance" in caplog.text
+
+
+def test_pair_config_to_dict_round_trips_types():
+    from core.database import PairConfig
+
+    row = PairConfig(
+        pair="XBTEUR",
+        target_pct=Decimal("30.000"),
+        hodl_pct=Decimal("10.000"),
+        k_act=Decimal("2.0000"),
+        min_margin=Decimal("0.00100000"),
+        stop_pct_ll=Decimal("0.900"),
+        stop_pct_lv=Decimal("0.900"),
+        stop_pct_mv=Decimal("0.900"),
+        stop_pct_hv=Decimal("0.900"),
+        stop_pct_hh=Decimal("0.950"),
+    )
+    d = row.to_dict()
+    assert d["pair"] == "XBTEUR"
+    assert d["target_pct"] == 30.0
+    assert d["k_act"] == 2.0
+    assert d["stop_pct_hh"] == 0.95
+    assert isinstance(d["min_margin"], float)
+
+
+def test_pair_config_to_dict_handles_null_k_act():
+    from core.database import PairConfig
+
+    row = PairConfig(
+        pair="ETHEUR",
+        target_pct=Decimal("0"),
+        hodl_pct=Decimal("0"),
+        k_act=None,
+        min_margin=Decimal("0.002"),
+        stop_pct_ll=Decimal("0.9"),
+        stop_pct_lv=Decimal("0.9"),
+        stop_pct_mv=Decimal("0.9"),
+        stop_pct_hv=Decimal("0.9"),
+        stop_pct_hh=Decimal("0.9"),
+    )
+    assert row.to_dict()["k_act"] is None

--- a/tests/unit/core/test_runtime.py
+++ b/tests/unit/core/test_runtime.py
@@ -13,3 +13,17 @@ def test_get_pair_data_returns_copy():
     result = runtime.get_pair_data("XBTEUR")
     result["last_price"] = 9999.0
     assert runtime.get_pair_data("XBTEUR")["last_price"] == 50000.0
+
+
+def test_config_dirty_flag_set_and_pop():
+    assert runtime.pop_config_dirty("XBTEUR") is False
+    runtime.mark_config_dirty("XBTEUR")
+    assert runtime.pop_config_dirty("XBTEUR") is True
+    # second pop returns False (cleared)
+    assert runtime.pop_config_dirty("XBTEUR") is False
+
+
+def test_config_dirty_flag_is_per_pair():
+    runtime.mark_config_dirty("ETHEUR")
+    assert runtime.pop_config_dirty("XBTEUR") is False
+    assert runtime.pop_config_dirty("ETHEUR") is True

--- a/tests/unit/core/test_scheduler.py
+++ b/tests/unit/core/test_scheduler.py
@@ -134,3 +134,35 @@ def test_trading_session_opens_position_when_trading_enabled(monkeypatch):
 
     assert len(created) == 1  # no stored position -> create_position is called once
     assert calls[0]["status"] == "completed"
+
+
+def test_trading_session_recalcs_params_when_config_dirty(monkeypatch):
+    _setup_one_pair_loop(monkeypatch)
+    monkeypatch.setattr(scheduler, "TRADING_ENABLED", False)
+    recalcs: list[str] = []
+    monkeypatch.setattr(scheduler, "calculate_trading_parameters", lambda pair: recalcs.append(pair))
+    # Force the counter off a PARAM_SESSIONS multiple so only the dirty flag can trigger.
+    monkeypatch.setattr(scheduler, "_session_count", 1)
+    monkeypatch.setattr(scheduler, "PARAM_SESSIONS", 720)
+    _patch_finalize(monkeypatch)
+
+    runtime.mark_config_dirty("XBTEUR")
+    scheduler.trading_session()
+
+    assert recalcs == ["XBTEUR"]
+
+
+def test_trading_session_no_recalc_when_not_dirty_and_off_cycle(monkeypatch):
+    _setup_one_pair_loop(monkeypatch)
+    monkeypatch.setattr(scheduler, "TRADING_ENABLED", False)
+    recalcs: list[str] = []
+    monkeypatch.setattr(scheduler, "calculate_trading_parameters", lambda pair: recalcs.append(pair))
+    monkeypatch.setattr(scheduler, "_session_count", 1)
+    monkeypatch.setattr(scheduler, "PARAM_SESSIONS", 720)
+    _patch_finalize(monkeypatch)
+
+    # ensure no leftover dirty flag from another test
+    runtime.pop_config_dirty("XBTEUR")
+    scheduler.trading_session()
+
+    assert recalcs == []

--- a/tests/unit/core/test_validation.py
+++ b/tests/unit/core/test_validation.py
@@ -1,3 +1,4 @@
+import core.config as config
 import core.validation as validation
 
 
@@ -86,15 +87,14 @@ def _stub_pair_config(
     allocation=None,
     stops=None,
 ):
-    """Replace the module-level config that validate_pair_params reads/writes."""
-    monkeypatch.setattr(validation, "PAIRS", {pair: {}})
-    monkeypatch.setattr(validation, "VOLATILITY_LEVELS", ("LL", "LV", "MV", "HV", "HH"))
-    default_trading = {"sell": {"K_ACT": "1.2", "MIN_MARGIN": "0"}, "buy": {"K_ACT": "1.2", "MIN_MARGIN": "0"}}
+    """Replace the config-module dicts that validate_pair_params reads/writes."""
+    monkeypatch.setattr(config, "PAIRS", {pair: {}})
+    default_trading = {"K_ACT": "1.2", "MIN_MARGIN": "0", "K_STOP": {"buy": {}, "sell": {}}}
     default_allocation = {"TARGET_PCT": "50", "HODL_PCT": "25"}
     default_stops = {lvl: "0.9" for lvl in ("LL", "LV", "MV", "HV", "HH")}
-    monkeypatch.setattr(validation, "TRADING_PARAMS", {pair: trading or default_trading})
-    monkeypatch.setattr(validation, "ASSET_ALLOCATION", {pair: allocation or default_allocation})
-    monkeypatch.setattr(validation, "STOP_PERCENTILES", {pair: stops or default_stops})
+    monkeypatch.setattr(config, "TRADING_PARAMS", {pair: trading or default_trading})
+    monkeypatch.setattr(config, "ASSET_ALLOCATION", {pair: allocation or default_allocation})
+    monkeypatch.setattr(config, "STOP_PERCENTILES", {pair: stops or default_stops})
 
 
 def test_validate_pair_params_happy_path_normalizes_values(monkeypatch) -> None:
@@ -103,57 +103,57 @@ def test_validate_pair_params_happy_path_normalizes_values(monkeypatch) -> None:
     validation.validate_pair_params(errors)
 
     assert errors == []
-    assert validation.TRADING_PARAMS["XBTEUR"]["sell"]["K_ACT"] == 1.2
-    assert validation.TRADING_PARAMS["XBTEUR"]["sell"]["MIN_MARGIN"] == 0.0
-    assert validation.ASSET_ALLOCATION["XBTEUR"]["TARGET_PCT"] == 50.0
-    assert validation.ASSET_ALLOCATION["XBTEUR"]["HODL_PCT"] == 25.0
-    assert validation.STOP_PERCENTILES["XBTEUR"]["LL"] == 0.9
+    assert config.TRADING_PARAMS["XBTEUR"]["K_ACT"] == 1.2
+    assert config.TRADING_PARAMS["XBTEUR"]["MIN_MARGIN"] == 0.0
+    assert config.ASSET_ALLOCATION["XBTEUR"]["TARGET_PCT"] == 50.0
+    assert config.ASSET_ALLOCATION["XBTEUR"]["HODL_PCT"] == 25.0
+    assert config.STOP_PERCENTILES["XBTEUR"]["LL"] == 0.9
 
 
-def test_validate_pair_params_empty_k_act_becomes_none_and_min_margin_required(monkeypatch) -> None:
+def test_validate_pair_params_empty_k_act_becomes_none_and_min_margin_used(monkeypatch) -> None:
     _stub_pair_config(
         monkeypatch,
-        trading={
-            "sell": {"K_ACT": "", "MIN_MARGIN": "0.5"},
-            "buy": {"K_ACT": None, "MIN_MARGIN": ""},
-        },
+        trading={"K_ACT": "", "MIN_MARGIN": "0.5", "K_STOP": {"buy": {}, "sell": {}}},
     )
     errors = []
     validation.validate_pair_params(errors)
 
-    assert validation.TRADING_PARAMS["XBTEUR"]["sell"]["K_ACT"] is None
-    assert validation.TRADING_PARAMS["XBTEUR"]["sell"]["MIN_MARGIN"] == 0.5
-    # buy side: K_ACT unset AND MIN_MARGIN unset → error.
-    assert any("XBTEUR_BUY_MIN_MARGIN is required" in e for e in errors)
+    assert errors == []
+    assert config.TRADING_PARAMS["XBTEUR"]["K_ACT"] is None
+    assert config.TRADING_PARAMS["XBTEUR"]["MIN_MARGIN"] == 0.5
+
+
+def test_validate_pair_params_min_margin_required_when_k_act_unset(monkeypatch) -> None:
+    _stub_pair_config(
+        monkeypatch,
+        trading={"K_ACT": None, "MIN_MARGIN": "", "K_STOP": {"buy": {}, "sell": {}}},
+    )
+    errors = []
+    validation.validate_pair_params(errors)
+    # K_ACT unset AND MIN_MARGIN unset → error.
+    assert any("XBTEUR_MIN_MARGIN is required" in e for e in errors)
 
 
 def test_validate_pair_params_invalid_k_act_flagged(monkeypatch) -> None:
     _stub_pair_config(
         monkeypatch,
-        trading={
-            "sell": {"K_ACT": "not-a-number", "MIN_MARGIN": "0"},
-            "buy": {"K_ACT": "1.0", "MIN_MARGIN": "0"},
-        },
+        trading={"K_ACT": "not-a-number", "MIN_MARGIN": "0", "K_STOP": {"buy": {}, "sell": {}}},
     )
     errors = []
     validation.validate_pair_params(errors)
-    assert any("XBTEUR_SELL_K_ACT must be a float" in e for e in errors)
+    assert any("XBTEUR_K_ACT must be a float" in e for e in errors)
 
 
 def test_validate_pair_params_min_margin_unused_when_k_act_defined(monkeypatch) -> None:
     _stub_pair_config(
         monkeypatch,
-        trading={
-            "sell": {"K_ACT": "1.5", "MIN_MARGIN": ""},
-            "buy": {"K_ACT": "1.5", "MIN_MARGIN": None},
-        },
+        trading={"K_ACT": "1.5", "MIN_MARGIN": "", "K_STOP": {"buy": {}, "sell": {}}},
     )
     errors = []
     validation.validate_pair_params(errors)
     # No error: MIN_MARGIN unused when K_ACT is defined. Normalized to 0.
     assert errors == []
-    assert validation.TRADING_PARAMS["XBTEUR"]["sell"]["MIN_MARGIN"] == 0.0
-    assert validation.TRADING_PARAMS["XBTEUR"]["buy"]["MIN_MARGIN"] == 0.0
+    assert config.TRADING_PARAMS["XBTEUR"]["MIN_MARGIN"] == 0.0
 
 
 def test_validate_pair_params_target_pct_over_100_flagged(monkeypatch) -> None:
@@ -171,20 +171,19 @@ def test_validate_pair_params_hodl_pct_over_100_flagged(monkeypatch) -> None:
 
 
 def test_validate_pair_params_target_pct_sum_over_100_flagged(monkeypatch) -> None:
-    monkeypatch.setattr(validation, "PAIRS", {"XBTEUR": {}, "ETHEUR": {}})
-    monkeypatch.setattr(validation, "VOLATILITY_LEVELS", ("LL", "LV", "MV", "HV", "HH"))
-    trading = {"sell": {"K_ACT": "1.2", "MIN_MARGIN": "0"}, "buy": {"K_ACT": "1.2", "MIN_MARGIN": "0"}}
+    monkeypatch.setattr(config, "PAIRS", {"XBTEUR": {}, "ETHEUR": {}})
+    trading = {"K_ACT": "1.2", "MIN_MARGIN": "0", "K_STOP": {"buy": {}, "sell": {}}}
     stops = {lvl: "0.9" for lvl in ("LL", "LV", "MV", "HV", "HH")}
-    monkeypatch.setattr(validation, "TRADING_PARAMS", {"XBTEUR": trading, "ETHEUR": trading})
+    monkeypatch.setattr(config, "TRADING_PARAMS", {"XBTEUR": dict(trading), "ETHEUR": dict(trading)})
     monkeypatch.setattr(
-        validation,
+        config,
         "ASSET_ALLOCATION",
         {
             "XBTEUR": {"TARGET_PCT": "60", "HODL_PCT": "10"},
             "ETHEUR": {"TARGET_PCT": "60", "HODL_PCT": "10"},
         },
     )
-    monkeypatch.setattr(validation, "STOP_PERCENTILES", {"XBTEUR": stops, "ETHEUR": stops})
+    monkeypatch.setattr(config, "STOP_PERCENTILES", {"XBTEUR": dict(stops), "ETHEUR": dict(stops)})
 
     errors = []
     validation.validate_pair_params(errors)
@@ -207,4 +206,4 @@ def test_validate_pair_params_stop_pct_empty_uses_default(monkeypatch) -> None:
     validation.validate_pair_params(errors)
     assert errors == []
     for lvl in ("LL", "LV", "MV", "HV", "HH"):
-        assert validation.STOP_PERCENTILES["XBTEUR"][lvl] == 0.90
+        assert config.STOP_PERCENTILES["XBTEUR"][lvl] == 0.90

--- a/tests/unit/optimizer/test_search.py
+++ b/tests/unit/optimizer/test_search.py
@@ -142,7 +142,7 @@ def test_run_optimize_no_global_mutation(monkeypatch) -> None:
     monkeypatch.setitem(
         config.TRADING_PARAMS,
         _PAIR,
-        {"buy": {"K_ACT": "1.0", "MIN_MARGIN": "0.005"}, "sell": {"K_ACT": "1.0", "MIN_MARGIN": "0.005"}},
+        {"K_ACT": "1.0", "MIN_MARGIN": "0.005"},
     )
     monkeypatch.setitem(config.PAIRS, _PAIR, {"atr_20pct": 1.0, "atr_50pct": 2.0})
 
@@ -160,7 +160,7 @@ def test_run_optimize_current_mode(monkeypatch) -> None:
     monkeypatch.setattr(
         optimizer,
         "TRADING_PARAMS",
-        {_PAIR: {"buy": {"K_ACT": None, "MIN_MARGIN": 0.005}, "sell": {"K_ACT": None, "MIN_MARGIN": 0.005}}},
+        {_PAIR: {"K_ACT": None, "MIN_MARGIN": 0.005}},
     )
     monkeypatch.setattr(optimizer, "STOP_PERCENTILES", {_PAIR: dict.fromkeys(_LEVELS, 0.9)})
 

--- a/tests/unit/services/test_telegram.py
+++ b/tests/unit/services/test_telegram.py
@@ -308,7 +308,7 @@ async def test_config_command_specific_pair(monkeypatch):
     await polling.config_command(update, MockContext(args=["XBTEUR"]))
 
     assert "XBTEUR" in update.message.replies[0]
-    assert "k_act: 2" in update.message.replies[0]
+    assert "Target %: 30" in update.message.replies[0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_telegram.py
+++ b/tests/unit/services/test_telegram.py
@@ -278,3 +278,89 @@ def test_notify_accepts_request_with_correct_token(monkeypatch):
 def test_notify_rejects_when_no_token_and_no_opt_in(monkeypatch):
     client, _ = _notify_client(monkeypatch, token=None, allow_no_auth=False)
     assert client.post("/notify", json={"message": "x", "level": "info"}).status_code == 401
+
+
+# ============================================================================
+# Config / Setconfig commands
+# ============================================================================
+
+_CONFIG_ITEM = {
+    "pair": "XBTEUR", "target_pct": 30.0, "hodl_pct": 10.0, "k_act": 2.0, "min_margin": 0.0,
+    "stop_pct_ll": 0.9, "stop_pct_lv": 0.9, "stop_pct_mv": 0.9, "stop_pct_hv": 0.9, "stop_pct_hh": 0.9,
+}
+
+
+@pytest.mark.asyncio
+async def test_config_command_specific_pair(monkeypatch):
+    monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
+    monkeypatch.setattr(polling, "PAIRS", {"XBTEUR": {}})
+    monkeypatch.setattr(polling, "client", _mock_client(get=_mock_response(_CONFIG_ITEM)))
+
+    update = MockUpdate()
+    await polling.config_command(update, MockContext(args=["XBTEUR"]))
+
+    assert "XBTEUR" in update.message.replies[0]
+    assert "k_act: 2" in update.message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_setconfig_command_patches_single_field(monkeypatch):
+    monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
+    monkeypatch.setattr(polling, "PAIRS", {"XBTEUR": {}})
+    mock = _mock_client()
+    mock.patch = __import__("unittest").mock.AsyncMock(return_value=_mock_response({**_CONFIG_ITEM, "target_pct": 25.0}))
+    monkeypatch.setattr(polling, "client", mock)
+
+    update = MockUpdate()
+    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "target_pct", "25"]))
+
+    mock.patch.assert_called_once_with("/config/XBTEUR", json={"target_pct": 25.0})
+    assert "✅" in update.message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_setconfig_command_k_act_none_sends_null(monkeypatch):
+    monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
+    monkeypatch.setattr(polling, "PAIRS", {"XBTEUR": {}})
+    mock = _mock_client()
+    mock.patch = __import__("unittest").mock.AsyncMock(return_value=_mock_response({**_CONFIG_ITEM, "k_act": None}))
+    monkeypatch.setattr(polling, "client", mock)
+
+    update = MockUpdate()
+    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "k_act", "none"]))
+
+    mock.patch.assert_called_once_with("/config/XBTEUR", json={"k_act": None})
+
+
+@pytest.mark.asyncio
+async def test_setconfig_command_bad_arity_shows_usage(monkeypatch):
+    monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
+    update = MockUpdate()
+    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "target_pct"]))
+    assert "Usage:" in update.message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_setconfig_command_unknown_field(monkeypatch):
+    monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
+    monkeypatch.setattr(polling, "PAIRS", {"XBTEUR": {}})
+    update = MockUpdate()
+    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "nonsense", "1"]))
+    assert "Unknown field" in update.message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_setconfig_command_none_rejected_for_non_k_act(monkeypatch):
+    monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
+    monkeypatch.setattr(polling, "PAIRS", {"XBTEUR": {}})
+    update = MockUpdate()
+    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "target_pct", "none"]))
+    assert "Only k_act" in update.message.replies[0]
+
+
+@pytest.mark.asyncio
+async def test_config_command_rejects_unauthorized(monkeypatch):
+    monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
+    update = MockUpdate(user_id=999)
+    await polling.config_command(update, MockContext())
+    assert update.message.replies == []

--- a/tests/unit/services/test_telegram.py
+++ b/tests/unit/services/test_telegram.py
@@ -285,8 +285,16 @@ def test_notify_rejects_when_no_token_and_no_opt_in(monkeypatch):
 # ============================================================================
 
 _CONFIG_ITEM = {
-    "pair": "XBTEUR", "target_pct": 30.0, "hodl_pct": 10.0, "k_act": 2.0, "min_margin": 0.0,
-    "stop_pct_ll": 0.9, "stop_pct_lv": 0.9, "stop_pct_mv": 0.9, "stop_pct_hv": 0.9, "stop_pct_hh": 0.9,
+    "pair": "XBTEUR",
+    "target_pct": 30.0,
+    "hodl_pct": 10.0,
+    "k_act": 2.0,
+    "min_margin": 0.0,
+    "stop_pct_ll": 0.9,
+    "stop_pct_lv": 0.9,
+    "stop_pct_mv": 0.9,
+    "stop_pct_hv": 0.9,
+    "stop_pct_hh": 0.9,
 }
 
 
@@ -308,7 +316,9 @@ async def test_setconfig_command_patches_single_field(monkeypatch):
     monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
     monkeypatch.setattr(polling, "PAIRS", {"XBTEUR": {}})
     mock = _mock_client()
-    mock.patch = __import__("unittest").mock.AsyncMock(return_value=_mock_response({**_CONFIG_ITEM, "target_pct": 25.0}))
+    mock.patch = __import__("unittest").mock.AsyncMock(
+        return_value=_mock_response({**_CONFIG_ITEM, "target_pct": 25.0})
+    )
     monkeypatch.setattr(polling, "client", mock)
 
     update = MockUpdate()

--- a/tests/unit/services/test_telegram.py
+++ b/tests/unit/services/test_telegram.py
@@ -316,9 +316,7 @@ async def test_setconfig_command_patches_single_field(monkeypatch):
     monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
     monkeypatch.setattr(polling, "PAIRS", {"XBTEUR": {}})
     mock = _mock_client()
-    mock.patch = __import__("unittest").mock.AsyncMock(
-        return_value=_mock_response({**_CONFIG_ITEM, "target_pct": 25.0})
-    )
+    mock.patch = AsyncMock(return_value=_mock_response({**_CONFIG_ITEM, "target_pct": 25.0}))
     monkeypatch.setattr(polling, "client", mock)
 
     update = MockUpdate()
@@ -333,7 +331,7 @@ async def test_setconfig_command_k_act_none_sends_null(monkeypatch):
     monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
     monkeypatch.setattr(polling, "PAIRS", {"XBTEUR": {}})
     mock = _mock_client()
-    mock.patch = __import__("unittest").mock.AsyncMock(return_value=_mock_response({**_CONFIG_ITEM, "k_act": None}))
+    mock.patch = AsyncMock(return_value=_mock_response({**_CONFIG_ITEM, "k_act": None}))
     monkeypatch.setattr(polling, "client", mock)
 
     update = MockUpdate()

--- a/tests/unit/services/test_telegram.py
+++ b/tests/unit/services/test_telegram.py
@@ -320,7 +320,7 @@ async def test_setconfig_command_patches_single_field(monkeypatch):
     monkeypatch.setattr(polling, "client", mock)
 
     update = MockUpdate()
-    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "target_pct", "25"]))
+    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "target", "25"]))
 
     mock.patch.assert_called_once_with("/config/XBTEUR", json={"target_pct": 25.0})
     assert "✅" in update.message.replies[0]
@@ -335,7 +335,7 @@ async def test_setconfig_command_k_act_none_sends_null(monkeypatch):
     monkeypatch.setattr(polling, "client", mock)
 
     update = MockUpdate()
-    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "k_act", "none"]))
+    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "kact", "none"]))
 
     mock.patch.assert_called_once_with("/config/XBTEUR", json={"k_act": None})
 
@@ -344,7 +344,7 @@ async def test_setconfig_command_k_act_none_sends_null(monkeypatch):
 async def test_setconfig_command_bad_arity_shows_usage(monkeypatch):
     monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
     update = MockUpdate()
-    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "target_pct"]))
+    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "target"]))
     assert "Usage:" in update.message.replies[0]
 
 
@@ -362,8 +362,8 @@ async def test_setconfig_command_none_rejected_for_non_k_act(monkeypatch):
     monkeypatch.setattr(polling, "TELEGRAM_USER_ID", "123456789")
     monkeypatch.setattr(polling, "PAIRS", {"XBTEUR": {}})
     update = MockUpdate()
-    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "target_pct", "none"]))
-    assert "Only k_act" in update.message.replies[0]
+    await polling.setconfig_command(update, MockContext(args=["XBTEUR", "target", "none"]))
+    assert "Only kact" in update.message.replies[0]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/trading/test_backtest.py
+++ b/tests/unit/trading/test_backtest.py
@@ -27,7 +27,7 @@ def _setup_common(monkeypatch, sample_dataframe) -> None:
     monkeypatch.setattr(
         backtest,
         "TRADING_PARAMS",
-        {_PAIR: {"buy": {"K_ACT": None, "MIN_MARGIN": 0.0}, "sell": {"K_ACT": None, "MIN_MARGIN": 0.0}}},
+        {_PAIR: {"K_ACT": None, "MIN_MARGIN": 0.0}},
     )
 
 

--- a/tests/unit/trading/test_engine.py
+++ b/tests/unit/trading/test_engine.py
@@ -46,8 +46,8 @@ def _cfg(
             k_stop_buy=kb,
             k_stop_sell=ks,
         ),
-        buy=engine.SidePolicy(k_act=k_act, min_margin=min_margin),
-        sell=engine.SidePolicy(k_act=k_act, min_margin=min_margin),
+        k_act=k_act,
+        min_margin=min_margin,
         atr_desv_limit=atr_desv_limit,
     )
 

--- a/tests/unit/trading/test_parameters_manager.py
+++ b/tests/unit/trading/test_parameters_manager.py
@@ -59,8 +59,10 @@ def test_get_k_stop_uses_fallbacks_when_current_level_missing(monkeypatch) -> No
         "TRADING_PARAMS",
         {
             "XBTEUR": {
-                "sell": {"K_STOP": {"LL": None, "LV": None, "MV": None, "HV": None, "HH": 5.5}},
-                "buy": {"K_STOP": {"LL": None, "LV": None, "MV": None, "HV": None, "HH": 4.4}},
+                "K_STOP": {
+                    "sell": {"LL": None, "LV": None, "MV": None, "HV": None, "HH": 5.5},
+                    "buy": {"LL": None, "LV": None, "MV": None, "HV": None, "HH": 4.4},
+                }
             }
         },
     )
@@ -99,7 +101,7 @@ def test_calculate_trading_parameters_updates_atr_and_k_stops(monkeypatch, sampl
     monkeypatch.setattr(
         parameters_manager,
         "TRADING_PARAMS",
-        {pair: {"sell": {"K_STOP": {}}, "buy": {"K_STOP": {}}}},
+        {pair: {"K_STOP": {"sell": {}, "buy": {}}}},
     )
 
     parameters_manager.calculate_trading_parameters(pair, infoLog=False)
@@ -111,7 +113,7 @@ def test_calculate_trading_parameters_updates_atr_and_k_stops(monkeypatch, sampl
     assert parameters_manager.PAIRS[pair]["atr_95pct"] == pytest.approx(4.5)
 
     # K_STOP sell side (from real uptrend events, 2 events X 5 vol levels)
-    sell = parameters_manager.TRADING_PARAMS[pair]["sell"]["K_STOP"]
+    sell = parameters_manager.TRADING_PARAMS[pair]["K_STOP"]["sell"]
     assert sell["LL"] == 10.0
     assert sell["LV"] == 3.4
     assert sell["MV"] == 2.0
@@ -119,7 +121,7 @@ def test_calculate_trading_parameters_updates_atr_and_k_stops(monkeypatch, sampl
     assert sell["HH"] == 1.2
 
     # K_STOP buy side (from real downtrend events, 2 events X 5 vol levels)
-    buy = parameters_manager.TRADING_PARAMS[pair]["buy"]["K_STOP"]
+    buy = parameters_manager.TRADING_PARAMS[pair]["K_STOP"]["buy"]
     assert buy["LL"] == 11.0
     assert buy["LV"] == 3.4
     assert buy["MV"] == 2.0

--- a/tests/unit/trading/test_parameters_manager_cache.py
+++ b/tests/unit/trading/test_parameters_manager_cache.py
@@ -25,7 +25,7 @@ def test_calculate_trading_parameters_populates_calibration_cache(monkeypatch, s
     monkeypatch.setattr(
         parameters_manager,
         "TRADING_PARAMS",
-        {pair: {"sell": {"K_STOP": {}}, "buy": {"K_STOP": {}}}},
+        {pair: {"K_STOP": {"sell": {}, "buy": {}}}},
     )
 
     parameters_manager.calculate_trading_parameters(pair, infoLog=False)

--- a/tests/unit/trading/test_positions_manager.py
+++ b/tests/unit/trading/test_positions_manager.py
@@ -14,7 +14,7 @@ def test_calculate_activation_price_uses_k_act_when_defined(monkeypatch) -> None
     monkeypatch.setattr(
         positions_manager,
         "TRADING_PARAMS",
-        {"XBTEUR": {"sell": {"K_ACT": 2.0, "MIN_MARGIN": 0.01}, "buy": {"K_ACT": 2.0, "MIN_MARGIN": 0.01}}},
+        {"XBTEUR": {"K_ACT": 2.0, "MIN_MARGIN": 0.01}},
     )
 
     result = positions_manager.calculate_activation_price("XBTEUR", "sell", 100.0, 5.0)
@@ -26,7 +26,7 @@ def test_calculate_activation_price_uses_k_stop_and_margin_fallback(monkeypatch)
     monkeypatch.setattr(
         positions_manager,
         "TRADING_PARAMS",
-        {"XBTEUR": {"sell": {"K_ACT": None, "MIN_MARGIN": 0.1}, "buy": {"K_ACT": None, "MIN_MARGIN": 0.1}}},
+        {"XBTEUR": {"K_ACT": None, "MIN_MARGIN": 0.1}},
     )
     monkeypatch.setattr(positions_manager, "get_k_stop", lambda pair, side, atr: 2.0)
 

--- a/trading/backtest.py
+++ b/trading/backtest.py
@@ -12,7 +12,7 @@ import numpy as np
 import core.database as db
 import core.runtime as runtime
 from core.config import ATR_DESV_LIMIT, CANDLE_TIMEFRAME, TRADING_PARAMS
-from trading.engine import EngineConfig, Operation, PairCalibration, SidePolicy, simulate_operations
+from trading.engine import EngineConfig, Operation, PairCalibration, simulate_operations
 from trading.market_analyzer import analyze_structural_noise
 from trading.parameters_manager import calculate_k_stops
 
@@ -128,15 +128,13 @@ def run_backtest(req: BacktestRequest) -> BacktestResult:
         k_stop_sell=calculate_k_stops(req.pair, up_events),
     )
 
-    side_buy = SidePolicy(
-        k_act=_coerce_float(TRADING_PARAMS[req.pair]["buy"].get("K_ACT")),
-        min_margin=float(TRADING_PARAMS[req.pair]["buy"].get("MIN_MARGIN") or 0.0),
+    cfg = EngineConfig(
+        req.pair,
+        calibration,
+        k_act=_coerce_float(TRADING_PARAMS[req.pair].get("K_ACT")),
+        min_margin=float(TRADING_PARAMS[req.pair].get("MIN_MARGIN") or 0.0),
+        atr_desv_limit=ATR_DESV_LIMIT,
     )
-    side_sell = SidePolicy(
-        k_act=_coerce_float(TRADING_PARAMS[req.pair]["sell"].get("K_ACT")),
-        min_margin=float(TRADING_PARAMS[req.pair]["sell"].get("MIN_MARGIN") or 0.0),
-    )
-    cfg = EngineConfig(req.pair, calibration, buy=side_buy, sell=side_sell, atr_desv_limit=ATR_DESV_LIMIT)
 
     operations = simulate_operations(df, cfg, fee_rate=req.fee_pct / 100.0, max_ops=req.max_ops)
     summary = _build_summary(operations, row_count=len(df), source=source)

--- a/trading/engine.py
+++ b/trading/engine.py
@@ -26,17 +26,11 @@ class PairCalibration:
 
 
 @dataclass(frozen=True)
-class SidePolicy:
-    k_act: float | None
-    min_margin: float
-
-
-@dataclass(frozen=True)
 class EngineConfig:
     pair: str
     calibration: PairCalibration
-    buy: SidePolicy
-    sell: SidePolicy
+    k_act: float | None
+    min_margin: float
     atr_desv_limit: float
 
 
@@ -104,12 +98,11 @@ def lookup_k_stop(cfg: EngineConfig, side: str, atr_val: float) -> float | None:
 
 
 def activation_distance(cfg: EngineConfig, side: str, reference_price: float, atr_val: float) -> float:
-    policy = cfg.sell if side == "sell" else cfg.buy
-    k_act = policy.k_act
+    k_act = cfg.k_act
     if k_act is not None:
         return float(k_act) * atr_val
     k_stop = lookup_k_stop(cfg, side, atr_val) or 0.0
-    return float(k_stop) * atr_val + (policy.min_margin * reference_price)
+    return float(k_stop) * atr_val + (cfg.min_margin * reference_price)
 
 
 def activation_price(cfg: EngineConfig, side: str, entry_price: float, atr_val: float) -> float:

--- a/trading/optimizer/search.py
+++ b/trading/optimizer/search.py
@@ -38,7 +38,7 @@ from optuna.samplers import TPESampler
 import core.database as db
 from core.config import ATR_DESV_LIMIT, CANDLE_TIMEFRAME, STOP_PERCENTILES, TRADING_PARAMS
 from core.config import VOLATILITY_LEVELS as LEVELS
-from trading.engine import EngineConfig, PairCalibration, SidePolicy, simulate_operations
+from trading.engine import EngineConfig, PairCalibration, simulate_operations
 from trading.market_analyzer import analyze_structural_noise
 
 optuna.logging.set_verbosity(optuna.logging.WARNING)
@@ -201,7 +201,7 @@ def _candidate_from_env(req: "OptimizerRequest") -> Candidate:
     if cur.k_act is not None:
         k_act = cur.k_act
     else:
-        raw_k_act = TRADING_PARAMS[pair]["buy"].get("K_ACT")
+        raw_k_act = TRADING_PARAMS[pair].get("K_ACT")
         try:
             k_act = float(raw_k_act) if raw_k_act is not None and str(raw_k_act).strip() != "" else None
         except (TypeError, ValueError):
@@ -209,7 +209,7 @@ def _candidate_from_env(req: "OptimizerRequest") -> Candidate:
     if cur.min_margin is not None:
         min_margin = cur.min_margin
     else:
-        raw_mm = TRADING_PARAMS[pair]["buy"].get("MIN_MARGIN", 0) or 0
+        raw_mm = TRADING_PARAMS[pair].get("MIN_MARGIN", 0) or 0
         try:
             min_margin = float(raw_mm)
         except (TypeError, ValueError):
@@ -252,8 +252,13 @@ def _build_engine_config(
         k_stop_buy=buy_k_stop,
         k_stop_sell=sell_k_stop,
     )
-    side = SidePolicy(k_act=cand.k_act, min_margin=cand.min_margin or 0.0)
-    return EngineConfig(pair=pair, calibration=calibration, buy=side, sell=side, atr_desv_limit=atr_desv_limit)
+    return EngineConfig(
+        pair=pair,
+        calibration=calibration,
+        k_act=cand.k_act,
+        min_margin=cand.min_margin or 0.0,
+        atr_desv_limit=atr_desv_limit,
+    )
 
 
 # --- Optuna search ---------------------------------------------------------

--- a/trading/parameters_manager.py
+++ b/trading/parameters_manager.py
@@ -63,8 +63,7 @@ def calculate_trading_parameters(pair: str, infoLog: bool = True) -> None:
     sell_k_stops = calculate_k_stops(pair, uptrend_events)
     buy_k_stops = calculate_k_stops(pair, downtrend_events)
 
-    TRADING_PARAMS[pair]["sell"]["K_STOP"] = sell_k_stops
-    TRADING_PARAMS[pair]["buy"]["K_STOP"] = buy_k_stops
+    TRADING_PARAMS[pair]["K_STOP"] = {"sell": sell_k_stops, "buy": buy_k_stops}
 
     if infoLog:
 
@@ -99,8 +98,8 @@ def build_calibration(pair: str) -> PairCalibration:
         atr_p50=float(PAIRS[pair]["atr_50pct"]),
         atr_p80=float(PAIRS[pair]["atr_80pct"]),
         atr_p95=float(PAIRS[pair]["atr_95pct"]),
-        k_stop_buy=dict(TRADING_PARAMS[pair]["buy"].get("K_STOP") or {}),
-        k_stop_sell=dict(TRADING_PARAMS[pair]["sell"].get("K_STOP") or {}),
+        k_stop_buy=dict(TRADING_PARAMS[pair]["K_STOP"].get("buy") or {}),
+        k_stop_sell=dict(TRADING_PARAMS[pair]["K_STOP"].get("sell") or {}),
     )
 
 
@@ -120,13 +119,13 @@ def get_volatility_level(pair: str, atr_val: float) -> str:
 def get_k_stop(pair: str, side: str, atr_val: float) -> float | None:
     vol = get_volatility_level(pair, atr_val)
 
-    k_stop = TRADING_PARAMS[pair][side]["K_STOP"].get(vol)
+    k_stop = TRADING_PARAMS[pair]["K_STOP"][side].get(vol)
     if k_stop is not None:
         return k_stop
 
     # Try opposite side K_STOP as fallback
     op_side = "buy" if side == "sell" else "sell"
-    k_stop = TRADING_PARAMS[pair][op_side]["K_STOP"].get(vol)
+    k_stop = TRADING_PARAMS[pair]["K_STOP"][op_side].get(vol)
     if k_stop is not None:
         return k_stop
 
@@ -135,7 +134,7 @@ def get_k_stop(pair: str, side: str, atr_val: float) -> float | None:
     for offset in range(1, len(LEVELS)):
         for neighbor in (idx - offset, idx + offset):
             if 0 <= neighbor < len(LEVELS):
-                k_stop = TRADING_PARAMS[pair][side]["K_STOP"].get(LEVELS[neighbor])
+                k_stop = TRADING_PARAMS[pair]["K_STOP"][side].get(LEVELS[neighbor])
                 if k_stop is not None:
                     return k_stop
 

--- a/trading/parameters_manager.py
+++ b/trading/parameters_manager.py
@@ -66,6 +66,8 @@ def calculate_trading_parameters(pair: str, infoLog: bool = True) -> None:
     TRADING_PARAMS[pair]["K_STOP"] = {"sell": sell_k_stops, "buy": buy_k_stops}
 
     if infoLog:
+        pct_msg = " | ".join(f"{lvl}:{STOP_PERCENTILES[pair][lvl]}" for lvl in LEVELS)
+        logging.info(f"Stop percentiles → {pct_msg}")
 
         def fmt(k):
             return f"{k:.2f}" if k is not None else "N/A"

--- a/trading/positions_manager.py
+++ b/trading/positions_manager.py
@@ -45,7 +45,7 @@ def create_position(
 
 
 def calculate_activation_distance(pair: str, side: str, reference_price: float, atr_val: float) -> float:
-    k_act = TRADING_PARAMS[pair][side]["K_ACT"]
+    k_act = TRADING_PARAMS[pair]["K_ACT"]
 
     if k_act is not None:
         # Use K_ACT if defined, K_ACT = 0 means immediate activation
@@ -53,7 +53,7 @@ def calculate_activation_distance(pair: str, side: str, reference_price: float, 
 
     # Use K_STOP and MIN_MARGIN if K_ACT is not defined
     k_stop = get_k_stop(pair, side, atr_val)
-    min_margin = float(TRADING_PARAMS[pair][side]["MIN_MARGIN"])
+    min_margin = float(TRADING_PARAMS[pair]["MIN_MARGIN"])
     return k_stop * atr_val + min_margin * reference_price
 
 


### PR DESCRIPTION
## Summary

- Adds a `pair_config` DB table (seeded once from `.env`) as the DB-authoritative source for per-pair trading params (`target_pct`, `hodl_pct`, `k_act`, `min_margin`, `stop_pct_<level>`), replacing the `.env`-only config.
- Introduces `core/config_store.py` as the single owner of dynamic config: `load_or_seed` at startup, `apply_patch` for validated atomic runtime updates (persist-then-apply, cross-pair target sum check, module lock).
- Exposes `GET /config`, `GET /config/{pair}`, `PATCH /config/{pair}` API endpoints (auth-protected) and Telegram `/config`/`/setconfig` commands for runtime edits without restart.
- `stop_pct` changes set a per-pair dirty flag in `core/runtime.py`; the scheduler recalculates `K_STOP` on the next session rather than in the request path.
- Collapses `k_act`/`min_margin` from per-side (`buy`/`sell`) to single per-pair values; removes `SidePolicy`; restructures `TRADING_PARAMS[pair]["K_STOP"]` to `["K_STOP"]["buy"|"sell"]` consistently across `engine`, `backtest`, `optimizer`, `parameters_manager`, `positions_manager`.
- Alembic migration `20260616_01` adds the `pair_config` table with nine check constraints matching the ORM model.

## Test plan

- [ ] Full unit suite passes locally: `PYTHONPATH=. pytest tests/unit/` (266 tests, 88% coverage)
- [ ] Ruff lint + format: `python -m ruff check . && python -m ruff format --check .`
- [ ] Migration applies cleanly: `docker compose -f docker-compose.test.yml run --rm test alembic upgrade head`
- [ ] `GET /config` returns all pairs after startup seed
- [ ] `PATCH /config/{pair}` with a `stop_pct` change causes `K_STOP` recalc on the next scheduler session
- [ ] `PATCH /config/{pair}` with `k_act: null` and no `min_margin` returns 422 when current `min_margin` is 0
- [ ] `/setconfig XBTEUR target_pct 25` via Telegram succeeds and the API reflects the change
- [ ] Restart bot after a patch — `load_or_seed` loads DB values, not `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3XuKF1esshpgMFoeXx6wK